### PR TITLE
fix propose_indexed bug

### DIFF
--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -168,7 +168,14 @@ where
         {
             Ok(er) => er.map_or_else(
                 |option_er| Ok(option_er.map(|r| Some(r.clone()))),
-                |err| Err(err.clone()),
+                |err| {
+                    if let &ProposeError::KeyConflict = err {
+                        // key conflict is ok as we alaways wait the sync result
+                        Ok(None)
+                    } else {
+                        Err(err.clone())
+                    }
+                },
             )?,
             Err(e) => return Err(ProposeError::RpcError(format!("{e}"))),
         }


### PR DESCRIPTION
Skip keyconflict error on the first rpc as we always wait the second
wait-sync response.