### PR TITLE
Temp workaround to clear speculative pool 

### DIFF
--- a/curp/src/server.rs
+++ b/curp/src/server.rs
@@ -397,6 +397,9 @@ impl<C: 'static + Command, CE: 'static + CommandExecutor<C>> Protocol<C, CE> {
                             sc.cmd().clone(),
                             EntryStatus::Unsynced,
                         ));
+
+                        // TODO: remove this workaround after commit feature is done.
+                        let _skip = Self::spec_remove_cmd(&Arc::clone(&self.spec), sc.cmd().id());
                         SyncResponse::Synced
                     }
                 }


### PR DESCRIPTION
Remove cmd from speculative pool after cmd is synced.
Without deleting cmd from speculative pool, speculative pool
increases infinitely very fast. This will causes big calculation
for conflict check.
With this wordaroud, it is still possible that cmd is synced
before cmd is proposed so that speculative pool will have cmd
that is never deleted. Need a formal fix for this.