### PR TITLE
[Curp] Fix concurrent bug

### DIFF
--- a/curp/src/gc.rs
+++ b/curp/src/gc.rs
@@ -1,0 +1,27 @@
+use crate::cmd::Command;
+use crate::server::SpeculativePool;
+use parking_lot::Mutex;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::Instant;
+
+/// How often spec should GC
+const SPEC_GC_INTERVAL: Duration = Duration::from_secs(10);
+
+/// Run background GC tasks for Curp server
+pub(crate) fn run_gc_tasks<C: Command + 'static>(spec: Arc<Mutex<SpeculativePool<C>>>) {
+    let _spec_gc_handle = tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(SPEC_GC_INTERVAL).await;
+            spec.lock().gc();
+        }
+    });
+}
+
+impl<C: Command + 'static> SpeculativePool<C> {
+    /// Speculative pool GC
+    pub(crate) fn gc(&mut self) {
+        let now = Instant::now();
+        self.ready.retain(|_, time| now - *time >= SPEC_GC_INTERVAL);
+    }
+}

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -139,5 +139,8 @@ mod sync_manager;
 /// Protobuf generated types that are used in RPC
 mod rpc;
 
+/// Background garbage collection for Curp server
+mod gc;
+
 pub use message::LogIndex;
 pub use rpc::ProtocolServer;


### PR DESCRIPTION
The bug will happen in the following situation:
1. A client proposes a command to all servers.
2. The leader receives the command, sync to others, and committed the command.
3. When a follower has not yet received the proposal from the client, it notices that the command is committed and executes it. When the execution is over, it will need to remove the command from spec pool. However, since the follower has not yet received a proposal from the client, it will find no such command in the spec pool.

Suggested fix:
When a follower tries to remove a non-exist command from spec pool, it will register the command id in an internal buffer. When the proposal is finally received, it will directly remove the command. (The ready pool needs to gc after some time)