### PR TITLE
fix a bug

### DIFF
--- a/curp/src/server.rs
+++ b/curp/src/server.rs
@@ -687,7 +687,7 @@ impl<C: 'static + Command, CE: 'static + CommandExecutor<C>> Protocol<C, CE> {
                 }
 
                 // the leader will sync the command to others while grabbing the lock so that the order of the command can be preserved
-                let sync_notify = match self.sync_to_others(term, &cmd, true) {
+                let sync_notify = match self.sync_to_others(term, &cmd, has_conflict) {
                     Ok(notify) => notify,
                     Err(err) => {
                         return ProposeResponse::new_error(

--- a/curp/tests/speculative_execute.rs
+++ b/curp/tests/speculative_execute.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::common::{create_servers_client, TestCommand, TestCommandResult, TestCommandType};
 use curp::cmd::ProposeId;
 
@@ -21,13 +23,25 @@ async fn speculative_execute() {
 
     for _ in 0..3 {
         let (t, key) = exe_rx.recv().await.unwrap();
+
         assert_eq!(t, TestCommandType::Get);
         assert_eq!(key, "A".to_owned());
     }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(500), exe_rx.recv())
+            .await
+            .is_err()
+    );
 
     for _ in 0..3 {
         let (t, key) = after_sync_rx.recv().await.unwrap();
+
         assert_eq!(t, TestCommandType::Get);
         assert_eq!(key, "A".to_owned());
     }
+    assert!(
+        tokio::time::timeout(Duration::from_millis(500), after_sync_rx.recv())
+            .await
+            .is_err()
+    );
 }


### PR DESCRIPTION
commands that have been executed speculatively should not be executed after sync