### PR TITLE
[Curp] Fix blocking caused by event listener wait() and improve kv_test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ scripts/*
 !scripts/Dockerfile
 !scripts/benchmark.sh
 !scripts/quick_start.sh
+
+.vscode
+.idea

--- a/xline/tests/kv_test.rs
+++ b/xline/tests/kv_test.rs
@@ -8,7 +8,7 @@ use xline::client::kv_types::{
 
 use crate::common::Cluster;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_kv_put() -> Result<(), Box<dyn Error>> {
     struct TestCase {
         req: PutRequest,
@@ -42,7 +42,7 @@ async fn test_kv_put() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_kv_get() -> Result<(), Box<dyn Error>> {
     struct TestCase<'a> {
         req: RangeRequest,
@@ -158,7 +158,7 @@ async fn test_kv_get() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 async fn test_kv_delete() -> Result<(), Box<dyn Error>> {
     struct TestCase<'a> {
         req: DeleteRangeRequest,


### PR DESCRIPTION
l.wait() should only be called in non-async code. If it is called in async code, it will not hand the control flow back to tokio runtime like l.await and, therefore, block the tokio worker thread.