### PR TITLE
fix proto compile error

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,8 +8,14 @@ Contribution Guide
 ```bash
 # Assume that rust compile environment installed, such as cargo, etc.
 
-# install dependency
-sudo apt install -y libprotobuf-dev protobuf-compiler
+# install dependency, requires protobuf-compiler >= 3.15
+git clone --branch v3.21.12  --recurse-submodules https://github.com/protocolbuffers/protobuf
+cd protobuf
+./autogen.sh
+./configure
+make -j
+sudo make install 
+
 
 # clone source code
 git clone https://github.com/datenlord/Xline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,13 @@ docker exec node4 /bin/sh -c "/usr/local/bin/etcdctl --endpoints=\"http://172.20
  docker exec node4 /bin/sh -c "/usr/local/bin/etcdctl --endpoints=\"http://172.20.0.3:2379\" get A"
 ```
 
+## Benchmark
+
+**Note: this script will stop all the running docker containers**
+```bash
+./scripts/benchmark.sh
+```
+
 # Directory Structure
 
 | directory name | description |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ protocol, which is quite popular in recently developed systems.
 Although Raft is stable and easy to implement, it takes 2 RTTs to complete a
 consensus request from the view of a client. One RTT takes place between the
 client and the leader server, and the leader server takes another RTT to
-broadcast the message to the follower leaders. In a geo-distributed environment,
+broadcast the message to the follower servers. In a geo-distributed environment,
 an RTT is quite long, varying from tens of milliseconds to hundreds of
 milliseconds, so 2 RTTs are too long in such cases.
 

--- a/curp/build.rs
+++ b/curp/build.rs
@@ -1,6 +1,5 @@
 fn main() {
     tonic_build::configure()
-        .protoc_arg("--experimental_allow_proto3_optional")
         .compile(&["./proto/message.proto"], &["./proto/"])
         .unwrap_or_else(|e| panic!("Failed to compile proto, error is {:?}", e));
 }

--- a/curp/build.rs
+++ b/curp/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
         .compile(&["./proto/message.proto"], &["./proto/"])
         .unwrap_or_else(|e| panic!("Failed to compile proto, error is {:?}", e));
 }

--- a/curp/src/server/bg_tasks.rs
+++ b/curp/src/server/bg_tasks.rs
@@ -148,7 +148,7 @@ async fn bg_append_entries<C: Command + 'static>(
                     error!("unable to serialize append entries request: {}", e);
                     continue;
                 }
-                Ok(req) => (req),
+                Ok(req) => req,
             }
         };
 


### PR DESCRIPTION
This pr aims to fix issue #115.  It added a build option `--experimental_allow_proto3_optional` to make the `cargo build --release` run successfully.

Signed-off-by: Phoeniix Zhao <Phoenix500526@163.com>