### PR TITLE
fix panic in a benchmark

### DIFF
--- a/benchmark/src/runner.rs
+++ b/benchmark/src/runner.rs
@@ -270,6 +270,14 @@ impl CommandRunner {
             bar.inc(1);
             stats.latencies.push(result.elapsed);
         }
+        assert!(
+            !stats.latencies.is_empty(),
+            "All requests failed! {:?}",
+            self.errors
+                .iter()
+                .max_by(|x, y| x.1.cmp(y.1))
+                .map(|(err, _)| err)
+        );
         stats.total = start.elapsed();
         stats.qps = stats.latencies.len() as f64 / stats.total.as_secs_f64();
         stats.avg =

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -86,6 +86,7 @@ run_cluster() {
         run_xline 1 &
         run_xline 2 &
         run_xline 3 &
+        sleep 0.2
         ;;
     etcd)
         run_etcd 1


### PR DESCRIPTION
A panic happened in the first bench case when I run the `benchmark.sh`.  That's because the benchmark program sent requests to the cluster while it is not yet booted up. 