### PR TITLE
Recovery on leader election

### DIFF
--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -41,6 +41,8 @@ itertools = "0.10.3"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
 tracing-test = "0.2.3"
 tower = { version = "0.4.13", features = ["filter"] }
+anyhow = "1.0.66"
+mockall = "0.11.3"
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/curp/proto/message.proto
+++ b/curp/proto/message.proto
@@ -68,6 +68,7 @@ message VoteRequest {
 message VoteResponse {
     uint64 term = 1;
     bool   vote_granted = 2;
+    repeated bytes spec_pool = 3;
 }
 
 service Protocol {

--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -1,5 +1,3 @@
-#[cfg(test)]
-use std::sync::atomic::AtomicBool;
 use std::{
     cmp::Ordering, collections::HashMap, fmt::Debug, iter, marker::PhantomData, sync::Arc,
     time::Duration,
@@ -17,7 +15,8 @@ use crate::{
     error::ProposeError,
     message::{ServerId, TermNum},
     rpc::{
-        self, Connect, FetchLeaderRequest, ProposeRequest, SyncError, SyncResult, WaitSyncedRequest,
+        connect::{Connect, ConnectInterface},
+        FetchLeaderRequest, ProposeRequest, SyncError, SyncResult, WaitSyncedRequest,
     },
 };
 
@@ -88,12 +87,7 @@ where
     pub async fn new(addrs: HashMap<ServerId, String>) -> Self {
         Self {
             state: RwLock::new(State::new()),
-            connects: rpc::try_connect(
-                addrs,
-                #[cfg(test)]
-                Arc::new(AtomicBool::new(true)),
-            )
-            .await,
+            connects: Connect::try_connect(addrs).await,
             phatom: PhantomData,
         }
     }

--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -103,4 +103,7 @@ where
 
     /// Execute the after_sync callback
     async fn after_sync(&self, cmd: &C, index: LogIndex) -> Result<C::ASR, ExecuteError>;
+
+    /// Reset the command executor to the initial state
+    async fn reset(&self);
 }

--- a/curp/src/error.rs
+++ b/curp/src/error.rs
@@ -6,14 +6,21 @@ use thiserror::Error;
 /// Error met when executing commands
 #[allow(clippy::module_name_repetitions)] // this-error generate code false-positive
 #[non_exhaustive]
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum ExecuteError {
     /// Command is invalid
     #[error("invalid command {0} ")]
     InvalidCommand(String),
     /// Met I/O error while executing
     #[error("meet io related error")]
-    IoError(#[from] io::Error),
+    IoError(String),
+}
+
+impl From<io::Error> for ExecuteError {
+    #[inline]
+    fn from(err: io::Error) -> Self {
+        Self::IoError(err.to_string())
+    }
 }
 
 /// Rpc Error

--- a/curp/src/error.rs
+++ b/curp/src/error.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::io;
+
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Error met when executing commands

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -108,6 +108,21 @@
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed
 )]
+#![cfg_attr(
+    test,
+    allow(
+        clippy::integer_arithmetic,
+        clippy::indexing_slicing,
+        unused_results,
+        clippy::unwrap_used,
+        clippy::str_to_string,
+        clippy::panic,
+        clippy::wildcard_enum_match_arm,
+        clippy::match_wildcard_for_single_variants,
+        clippy::all,
+        dead_code
+    )
+)]
 
 pub use message::LogIndex;
 pub use rpc::ProtocolServer;

--- a/curp/src/log.rs
+++ b/curp/src/log.rs
@@ -1,5 +1,6 @@
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
 
 use crate::{cmd::Command, message::TermNum};
 

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -1,0 +1,267 @@
+#[cfg(test)]
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+#[cfg(test)]
+use mockall::automock;
+use tokio::sync::RwLock;
+use tracing::debug;
+
+use crate::{
+    error::ProposeError,
+    message::ServerId,
+    rpc::{
+        proto::protocol_client::ProtocolClient, AppendEntriesRequest, AppendEntriesResponse,
+        FetchLeaderRequest, FetchLeaderResponse, ProposeRequest, ProposeResponse, VoteRequest,
+        VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
+    },
+    util::Inject,
+};
+
+/// Connect interface
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub(crate) trait ConnectInterface: Send + Sync + 'static {
+    /// Get server id
+    fn id(&self) -> &ServerId;
+
+    /// Get the internal rpc connection/client
+    async fn get(
+        &self,
+    ) -> Result<ProtocolClient<tonic::transport::Channel>, tonic::transport::Error>;
+
+    /// send "propose" request
+    async fn propose(
+        &self,
+        request: ProposeRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<ProposeResponse>, ProposeError>;
+
+    /// send "wait synced" request
+    async fn wait_synced(
+        &self,
+        req: WaitSyncedRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<WaitSyncedResponse>, ProposeError>;
+
+    /// Send `AppendEntries` request
+    async fn append_entries(
+        &self,
+        request: AppendEntriesRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<AppendEntriesResponse>, ProposeError>;
+
+    /// Send `Vote` request
+    async fn vote(
+        &self,
+        request: VoteRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<VoteResponse>, ProposeError>;
+
+    /// Send `FetchLeaderRequest`
+    async fn fetch_leader(
+        &self,
+        request: FetchLeaderRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<FetchLeaderResponse>, ProposeError>;
+
+    /// Convert a vec of addr string to a vec of `Connect`
+    async fn try_connect(addrs: HashMap<ServerId, String>) -> Vec<Arc<Self>>;
+
+    /// Convert a vec of addr string to a vec of `Connect`
+    #[cfg(test)]
+    async fn try_connect_test(
+        addrs: HashMap<ServerId, String>,
+        reachable: Arc<AtomicBool>,
+    ) -> Vec<Arc<Self>>;
+}
+
+/// The connection struct to hold the real rpc connections, it may failed to connect, but it also
+/// retries the next time
+#[derive(Debug)]
+pub(crate) struct Connect {
+    /// Server id
+    id: ServerId,
+    /// The rpc connection, if it fails it contains a error, otherwise the rpc client is there
+    rpc_connect: RwLock<Result<ProtocolClient<tonic::transport::Channel>, tonic::transport::Error>>,
+    /// The addr used to connect if failing met
+    addr: String,
+    /// Whether the client can reach others, useful for testings
+    #[cfg(test)]
+    reachable: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl ConnectInterface for Connect {
+    /// Get server id
+    fn id(&self) -> &ServerId {
+        &self.id
+    }
+
+    /// Get the internal rpc connection/client
+    async fn get(
+        &self,
+    ) -> Result<ProtocolClient<tonic::transport::Channel>, tonic::transport::Error> {
+        if let Ok(ref client) = *self.rpc_connect.read().await {
+            return Ok(client.clone());
+        }
+        let mut connect_write = self.rpc_connect.write().await;
+        if let Ok(ref client) = *connect_write {
+            return Ok(client.clone());
+        }
+        let client = ProtocolClient::<_>::connect(self.addr.clone())
+            .await
+            .map(|client| {
+                *connect_write = Ok(client.clone());
+                client
+            })?;
+        *connect_write = Ok(client.clone());
+        Ok(client)
+    }
+
+    /// send "propose" request
+    async fn propose(
+        &self,
+        request: ProposeRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<ProposeResponse>, ProposeError> {
+        #[cfg(test)]
+        if !self.reachable.load(Ordering::Relaxed) {
+            return Err(ProposeError::RpcError("unreachable".to_owned()));
+        }
+
+        let mut client = self.get().await?;
+        let mut req = tonic::Request::new(request);
+        req.set_timeout(timeout);
+        req.metadata_mut().inject_current();
+        client.propose(req).await.map_err(Into::into)
+    }
+
+    /// send "wait synced" request
+    #[allow(dead_code)] // false positive report
+    async fn wait_synced(
+        &self,
+        request: WaitSyncedRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<WaitSyncedResponse>, ProposeError> {
+        #[cfg(test)]
+        if !self.reachable.load(Ordering::Relaxed) {
+            return Err(ProposeError::RpcError("unreachable".to_owned()));
+        }
+
+        let mut client = self.get().await?;
+        let mut req = tonic::Request::new(request);
+        req.set_timeout(timeout);
+        req.metadata_mut().inject_current();
+        client.wait_synced(req).await.map_err(Into::into)
+    }
+
+    /// Send `AppendEntries` request
+    async fn append_entries(
+        &self,
+        request: AppendEntriesRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<AppendEntriesResponse>, ProposeError> {
+        #[cfg(test)]
+        if !self.reachable.load(Ordering::Relaxed) {
+            return Err(ProposeError::RpcError("unreachable".to_owned()));
+        }
+
+        let mut client = self.get().await?;
+        let mut req = tonic::Request::new(request);
+        req.set_timeout(timeout);
+        client.append_entries(req).await.map_err(Into::into)
+    }
+
+    /// Send `Vote` request
+    async fn vote(
+        &self,
+        request: VoteRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<VoteResponse>, ProposeError> {
+        #[cfg(test)]
+        if !self.reachable.load(Ordering::Relaxed) {
+            return Err(ProposeError::RpcError("unreachable".to_owned()));
+        }
+
+        let mut client = self.get().await?;
+        let mut req = tonic::Request::new(request);
+        req.set_timeout(timeout);
+        client.vote(req).await.map_err(Into::into)
+    }
+
+    /// Send `FetchLeaderRequest`
+    async fn fetch_leader(
+        &self,
+        request: FetchLeaderRequest,
+        timeout: Duration,
+    ) -> Result<tonic::Response<FetchLeaderResponse>, ProposeError> {
+        #[cfg(test)]
+        if !self.reachable.load(Ordering::Relaxed) {
+            return Err(ProposeError::RpcError("unreachable".to_owned()));
+        }
+
+        let mut client = self.get().await?;
+        let mut req = tonic::Request::new(request);
+        req.set_timeout(timeout);
+        client.fetch_leader(req).await.map_err(Into::into)
+    }
+    /// Convert a vec of addr string to a vec of `Connect`
+    async fn try_connect(addrs: HashMap<ServerId, String>) -> Vec<Arc<Self>> {
+        futures::future::join_all(addrs.into_iter().map(|(id, mut addr)| async move {
+            // Addrs must start with "http" to communicate with the server
+            if !addr.starts_with("http") {
+                addr.insert_str(0, "http://");
+            }
+            (
+                id,
+                addr.clone(),
+                ProtocolClient::<_>::connect(addr.clone()).await,
+            )
+        }))
+        .await
+        .into_iter()
+        .map(|(id, addr, conn)| {
+            debug!("successfully establish connection with {addr}");
+            Arc::new(Connect {
+                id,
+                rpc_connect: RwLock::new(conn),
+                addr,
+                #[cfg(test)]
+                reachable: Arc::new(AtomicBool::new(true)),
+            })
+        })
+        .collect()
+    }
+    /// Convert a vec of addr string to a vec of `Connect`
+    #[cfg(test)]
+    async fn try_connect_test(
+        addrs: HashMap<ServerId, String>,
+        reachable: Arc<AtomicBool>,
+    ) -> Vec<Arc<Self>> {
+        futures::future::join_all(addrs.into_iter().map(|(id, mut addr)| async move {
+            // Addrs must start with "http" to communicate with the server
+            if !addr.starts_with("http") {
+                addr.insert_str(0, "http://");
+            }
+            (
+                id,
+                addr.clone(),
+                ProtocolClient::<_>::connect(addr.clone()).await,
+            )
+        }))
+        .await
+        .into_iter()
+        .map(|(id, addr, conn)| {
+            debug!("successfully establish connection with {addr}");
+            Arc::new(Connect {
+                id,
+                rpc_connect: RwLock::new(conn),
+                addr,
+                reachable: Arc::clone(&reachable),
+            })
+        })
+        .collect()
+    }
+}

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -1,5 +1,5 @@
 use clippy_utilities::NumericCast;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 pub use self::proto::protocol_server::ProtocolServer;
 pub(crate) use self::proto::{
@@ -318,17 +318,34 @@ impl VoteRequest {
 
 impl VoteResponse {
     /// Create a new accepted vote response
-    pub fn new_accept(term: TermNum) -> Self {
-        Self {
+    pub fn new_accept<C: Command + Serialize>(
+        term: TermNum,
+        cmds: Vec<C>,
+    ) -> bincode::Result<Self> {
+        Ok(Self {
             term: term.numeric_cast(),
             vote_granted: true,
-        }
+            spec_pool: cmds
+                .into_iter()
+                .map(|c| bincode::serialize(&c))
+                .collect::<bincode::Result<Vec<Vec<u8>>>>()?,
+        })
     }
+
     /// Create a new rejected vote response
     pub fn new_reject(term: TermNum) -> Self {
         Self {
             term: term.numeric_cast(),
             vote_granted: false,
+            spec_pool: vec![],
         }
+    }
+
+    /// Get spec pool
+    pub fn spec_pool<C: Command + DeserializeOwned>(self) -> bincode::Result<Vec<C>> {
+        self.spec_pool
+            .into_iter()
+            .map(|cmd| bincode::deserialize(&cmd))
+            .collect()
     }
 }

--- a/curp/src/server/bg_tasks.rs
+++ b/curp/src/server/bg_tasks.rs
@@ -3,21 +3,17 @@ use std::sync::atomic::AtomicBool;
 use std::{iter, ops::Range, sync::Arc, time::Duration};
 
 use clippy_utilities::NumericCast;
-use futures::future::Either;
 use lock_utils::parking_lot_lock::RwLockMap;
 use madsim::rand::{thread_rng, Rng};
 use parking_lot::{lock_api::RwLockUpgradableReadGuard, Mutex, RwLock};
 use tokio::{sync::mpsc, task::JoinHandle, time::Instant};
 use tracing::{debug, error, info, warn};
 
-use super::{
-    cmd_board::{CmdState, CommandBoard},
-    SyncMessage,
-};
+use super::SyncMessage;
 use crate::{
     cmd::{Command, CommandExecutor},
     log::LogEntry,
-    rpc::{connect::ConnectInterface, AppendEntriesRequest, VoteRequest, WaitSyncedResponse},
+    rpc::{connect::ConnectInterface, AppendEntriesRequest, VoteRequest},
     server::{
         cmd_execute_worker::{
             execute_worker, CmdExeReceiver, CmdExeSender, CmdExeSenderInterface, N_EXECUTE_WORKERS,
@@ -25,7 +21,6 @@ use crate::{
         ServerRole, SpeculativePool, State,
     },
     shutdown::Shutdown,
-    LogIndex,
 };
 
 /// Wait for sometime before next retry
@@ -69,13 +64,14 @@ pub(super) async fn run_bg_tasks<
     let bg_heartbeat_handle = tokio::spawn(bg_heartbeat(connects.clone(), Arc::clone(&state)));
     let bg_get_sync_cmds_handle =
         tokio::spawn(bg_get_sync_cmds(Arc::clone(&state), sync_chan, ae_trigger));
-    let calibrate_handle = tokio::spawn(bg_leader_calibrates_followers(connects, state));
+    let calibrate_handle =
+        tokio::spawn(bg_leader_calibrates_followers(connects, Arc::clone(&state)));
 
     // spawn cmd execute worker
     let bg_exe_worker_handles: Vec<JoinHandle<_>> =
-        iter::repeat((cmd_exe_rx, Arc::new(cmd_executor)))
+        iter::repeat((cmd_exe_rx, state.read().cmd_board(), Arc::new(cmd_executor)))
             .take(N_EXECUTE_WORKERS)
-            .map(|(rx, ce)| tokio::spawn(execute_worker(rx, ce)))
+            .map(|(rx, cmd_board, ce)| tokio::spawn(execute_worker(rx, cmd_board, ce)))
             .collect();
 
     shutdown.recv().await;
@@ -312,8 +308,7 @@ async fn bg_apply<C: Command + 'static, Tx: CmdExeSenderInterface<C>>(
     exe_tx: Tx,
     spec: Arc<Mutex<SpeculativePool<C>>>,
 ) {
-    let (commit_trigger, cmd_board) =
-        state.map_read(|state_r| (state_r.commit_trigger(), state_r.cmd_board()));
+    let commit_trigger = state.map_read(|state_r| state_r.commit_trigger());
     loop {
         // wait until there is something to commit
         let state = loop {
@@ -330,106 +325,15 @@ async fn bg_apply<C: Command + 'static, Tx: CmdExeSenderInterface<C>>(
         #[allow(clippy::integer_arithmetic, clippy::indexing_slicing)]
         // TODO: overflow of log index should be prevented
         for i in (state.last_applied + 1)..=state.commit_index {
-            for cmd in state.log[i].cmds().iter() {
-                let cmd_id = cmd.id();
-                if state.is_leader() {
-                    handle_after_sync_leader(
-                        Arc::clone(&cmd_board),
-                        Arc::clone(cmd),
-                        i.numeric_cast(),
-                        &exe_tx,
-                    );
-                } else {
-                    handle_after_sync_follower(&exe_tx, Arc::clone(cmd), i.numeric_cast());
-                }
-                spec.lock().mark_ready(cmd_id);
-            }
+            state.log[i].cmds().iter().cloned().for_each(|cmd| {
+                // clean up spec pool
+                spec.lock().mark_ready(cmd.id());
+                exe_tx.send_after_sync(cmd, i.numeric_cast());
+            });
             state.last_applied = i;
             debug!("log[{i}] committed, last_applied updated to {}", i);
         }
     }
-}
-
-/// The leader handles after sync
-fn handle_after_sync_leader<C: Command + 'static, Tx: CmdExeSenderInterface<C>>(
-    cmd_board: Arc<Mutex<CommandBoard>>,
-    cmd: Arc<C>,
-    index: LogIndex,
-    exe_tx: &Tx,
-) {
-    let cmd_id = cmd.id().clone();
-
-    let needs_execute = {
-        // the leader will see if the command needs execution from cmd board
-        let cmd_board = cmd_board.lock();
-        let cmd_state = if let Some(cmd_state) = cmd_board.cmd_states.get(cmd.id()) {
-            cmd_state
-        } else {
-            error!("No cmd {:?} in command board", cmd.id());
-            return;
-        };
-        match *cmd_state {
-            CmdState::Execute => true,
-            CmdState::AfterSync => false,
-            CmdState::EarlyArrive | CmdState::FinalResponse(_) => {
-                error!("should not get state {:?} before after sync", cmd_state);
-                return;
-            }
-        }
-    };
-
-    let resp = if needs_execute {
-        let result = exe_tx.send_exe_and_after_sync(cmd, index);
-        Either::Left(async move {
-            result.await.map_or_else(
-                |e| {
-                    error!("can't receive exe result from exe worker, {e}");
-                    WaitSyncedResponse::new_from_result::<C>(None, None)
-                },
-                |(er, asr)| WaitSyncedResponse::new_from_result::<C>(Some(er), asr),
-            )
-        })
-    } else {
-        let result = exe_tx.send_after_sync(cmd, index);
-        Either::Right(async move {
-            result.await.map_or_else(
-                |e| {
-                    error!("can't receive exe result from exe worker, {e}");
-                    WaitSyncedResponse::new_from_result::<C>(None, None)
-                },
-                |asr| WaitSyncedResponse::new_from_result::<C>(None, Some(asr)),
-            )
-        })
-    };
-
-    // update the cmd_board after execution and after_sync is completed
-    let _ignored = tokio::spawn(async move {
-        let resp = resp.await;
-
-        let mut cmd_board = cmd_board.lock();
-        let cmd_state = if let Some(cmd_state) = cmd_board.cmd_states.get_mut(&cmd_id) {
-            cmd_state
-        } else {
-            error!("No cmd {:?} in command board", cmd_id);
-            return;
-        };
-        *cmd_state = CmdState::FinalResponse(resp);
-
-        // now we can notify the waiting request
-        if let Some(notify) = cmd_board.notifiers.get(&cmd_id) {
-            notify.notify(usize::MAX);
-        }
-    });
-}
-
-/// The follower handles after sync
-fn handle_after_sync_follower<C: Command + 'static, Tx: CmdExeSenderInterface<C>>(
-    exe_tx: &Tx,
-    cmd: Arc<C>,
-    index: LogIndex,
-) {
-    // FIXME: should follower store er and asr in case it becomes leader later?
-    let _ignore = exe_tx.send_exe_and_after_sync(cmd, index);
 }
 
 /// How long a candidate should wait before it starts another round of election
@@ -653,7 +557,7 @@ mod test {
     use std::{collections::HashMap, sync::Arc};
 
     use parking_lot::{Mutex, RwLock};
-    use tokio::{sync::oneshot, time::Instant};
+    use tokio::time::Instant;
     use tracing_test::traced_test;
 
     use super::*;
@@ -662,7 +566,7 @@ mod test {
         error::ProposeError,
         log::LogEntry,
         rpc::{
-            connect::MockConnectInterface, AppendEntriesRequest, AppendEntriesResponse, SyncResult,
+            connect::MockConnectInterface, AppendEntriesRequest, AppendEntriesResponse,
             VoteRequest, VoteResponse,
         },
         server::{
@@ -685,7 +589,7 @@ mod test {
             LEADER_ID.to_owned(),
             ServerRole::Leader,
             others,
-            Arc::new(Mutex::new(CommandBoard::new())),
+            Arc::new(RwLock::new(CommandBoard::new())),
             Arc::new(RwLock::new(Instant::now())),
         )))
     }
@@ -880,53 +784,29 @@ mod test {
     async fn leader_will_apply_logs_after_commit() {
         let state = new_test_state();
         let mut spec = SpeculativePool::new();
-        let (id1, id2) = {
+        {
             let mut state = state.write();
             let cmd_board = state.cmd_board();
-            let mut cmd_board = cmd_board.lock();
+            let mut cmd_board = cmd_board.write();
 
-            let cmd1 = TestCommand::new_get(vec![1]);
-            let id1 = cmd1.id().clone();
-            spec.push(cmd1.clone());
-            cmd_board
-                .cmd_states
-                .insert(cmd1.id().clone(), CmdState::Execute);
-            state.log.push(LogEntry::new(0, &[Arc::new(cmd1)]));
+            let cmd1 = Arc::new(TestCommand::new_get(vec![1]));
+            spec.insert(Arc::clone(&cmd1));
+            cmd_board.needs_exe.insert(cmd1.id().clone());
+            state.log.push(LogEntry::new(0, &[cmd1]));
 
-            let cmd2 = TestCommand::default();
-            let id2 = cmd2.id().clone();
-            spec.push(cmd2.clone());
-            cmd_board
-                .cmd_states
-                .insert(cmd2.id().clone(), CmdState::AfterSync);
-            state.log.push(LogEntry::new(0, &[Arc::new(cmd2)]));
+            let cmd2 = Arc::new(TestCommand::default());
+            spec.insert(Arc::clone(&cmd2));
+            state.log.push(LogEntry::new(0, &[cmd2]));
 
             state.commit_index = 2;
-            (id1, id2)
-        };
+        }
         let spec = Arc::new(Mutex::new(spec));
 
         let mut exe_tx = MockCmdExeSenderInterface::default();
-        let id1_c = id1.clone();
-        exe_tx
-            .expect_send_exe_and_after_sync()
-            .return_once(move |cmd: Arc<TestCommand>, index| {
-                assert_eq!(cmd.id(), &id1_c);
-                assert_eq!(index, 1);
-                let (tx, rx) = oneshot::channel();
-                tx.send((Ok(vec![]), Some(Ok(1)))).unwrap();
-                rx
-            });
-        let id2_c = id2.clone();
         exe_tx
             .expect_send_after_sync()
-            .return_once(move |cmd: Arc<TestCommand>, index| {
-                assert_eq!(cmd.id(), &id2_c);
-                assert_eq!(index, 2);
-                let (tx, rx) = oneshot::channel();
-                tx.send(Ok(2)).unwrap();
-                rx
-            });
+            .times(2)
+            .returning(move |_cmd: Arc<TestCommand>, _index| {});
 
         let (state_c, spec_c) = (Arc::clone(&state), Arc::clone(&spec));
         let handle = tokio::spawn(async move {
@@ -935,41 +815,8 @@ mod test {
 
         sleep_millis(500).await;
 
-        // check
-        let state = state.read();
-        let cmd_board = state.cmd_board();
-        let mut cmd_board = cmd_board.lock();
-        let spec = spec.lock();
-
-        let resp1 = cmd_board.cmd_states.remove(&id1).unwrap();
-        let resp1: SyncResult<TestCommand> = match resp1 {
-            CmdState::FinalResponse(resp1) => resp1.unwrap().into().unwrap(),
-            _ => panic!(),
-        };
-        match resp1 {
-            SyncResult::Success { er, asr } => {
-                assert!(er.is_some());
-                assert_eq!(asr, 1);
-            }
-            _ => panic!(),
-        }
-
-        let resp2 = cmd_board.cmd_states.remove(&id2).unwrap();
-        let resp2: SyncResult<TestCommand> = match resp2 {
-            CmdState::FinalResponse(resp2) => resp2.unwrap().into().unwrap(),
-            _ => panic!(),
-        };
-        match resp2 {
-            SyncResult::Success { er, asr } => {
-                assert!(er.is_none());
-                assert_eq!(asr, 2);
-            }
-            _ => panic!(),
-        }
-
-        assert!(spec.pool.is_empty());
-        assert!(spec.ready.is_empty());
-        assert_eq!(state.last_applied, 2);
+        assert!(spec.lock().pool.is_empty());
+        assert_eq!(state.read().last_applied, 2);
 
         handle.abort();
     }

--- a/curp/src/server/bg_tasks.rs
+++ b/curp/src/server/bg_tasks.rs
@@ -100,16 +100,15 @@ async fn bg_get_sync_cmds<C: Command + 'static>(
             }
         };
 
-        #[allow(clippy::shadow_unrelated)] // clippy false positive
-        state.map_write(|mut state| {
-            state.log.push(LogEntry::new(term, &[cmd]));
-            if let Err(e) = ae_trigger.send(state.last_log_index()) {
+        state.map_write(|mut state_w| {
+            state_w.log.push(LogEntry::new(term, &[cmd]));
+            if let Err(e) = ae_trigger.send(state_w.last_log_index()) {
                 error!("ae_trigger failed: {}", e);
             }
 
             debug!(
                 "received new log, index {:?}",
-                state.log.len().checked_sub(1),
+                state_w.log.len().checked_sub(1),
             );
         });
     }
@@ -262,15 +261,14 @@ async fn bg_heartbeat<C: Command + 'static>(
 #[allow(clippy::integer_arithmetic, clippy::indexing_slicing)] // log.len() >= 1 because we have a fake log[0], indexing of `next_index` or `match_index` won't panic because we created an entry when initializing the server state
 async fn send_heartbeat<C: Command + 'static>(connect: Arc<Connect>, state: Arc<RwLock<State<C>>>) {
     // prepare append_entries request args
-    #[allow(clippy::shadow_unrelated)] // clippy false positive
-    let req = state.map_read(|state| {
-        let next_index = state.next_index[connect.id()];
+    let req = state.map_read(|state_r| {
+        let next_index = state_r.next_index[connect.id()];
         AppendEntriesRequest::new_heartbeat(
-            state.term,
-            state.id().clone(),
+            state_r.term,
+            state_r.id().clone(),
             next_index - 1,
-            state.log[next_index - 1].term(),
-            state.commit_index,
+            state_r.log[next_index - 1].term(),
+            state_r.commit_index,
         )
     });
 
@@ -305,9 +303,8 @@ async fn bg_apply<C: Command + 'static>(
     exe_tx: CmdExeSender<C>,
     spec: Arc<Mutex<SpeculativePool<C>>>,
 ) {
-    #[allow(clippy::shadow_unrelated)]
     let (commit_trigger, cmd_board) =
-        state.map_read(|state| (state.commit_trigger(), state.cmd_board()));
+        state.map_read(|state_r| (state_r.commit_trigger(), state_r.cmd_board()));
     loop {
         // wait until there is something to commit
         let state = loop {
@@ -436,9 +433,8 @@ async fn bg_election<C: Command + 'static>(
     connects: Vec<Arc<Connect>>,
     state: Arc<RwLock<State<C>>>,
 ) {
-    #[allow(clippy::shadow_unrelated)]
     let (role_trigger, last_rpc_time) =
-        state.map_read(|state| (state.role_trigger(), state.last_rpc_time()));
+        state.map_read(|state_r| (state_r.role_trigger(), state_r.last_rpc_time()));
     loop {
         // only follower or candidate should run this task
         while state.read().is_leader() {
@@ -576,23 +572,22 @@ async fn leader_calibrates_followers<C: Command + 'static>(
             let _handle = tokio::spawn(async move {
                 loop {
                     // send append entry
-                    #[allow(clippy::shadow_unrelated)] // clippy false positive
                     let (req, last_sent_index) = {
-                        let state = state.read();
-                        let next_index = state.next_index[connect.id()];
+                        let state_r = state.read();
+                        let next_index = state_r.next_index[connect.id()];
                         match AppendEntriesRequest::new(
-                            state.term,
-                            state.id().clone(),
+                            state_r.term,
+                            state_r.id().clone(),
                             next_index - 1,
-                            state.log[next_index - 1].term(),
-                            state.log[next_index..].to_vec(),
-                            state.commit_index,
+                            state_r.log[next_index - 1].term(),
+                            state_r.log[next_index..].to_vec(),
+                            state_r.commit_index,
                         ) {
                             Err(e) => {
                                 error!("unable to serialize append entries request: {}", e);
                                 return;
                             }
-                            Ok(req) => (req, state.log.len() - 1),
+                            Ok(req) => (req, state_r.log.len() - 1),
                         }
                     };
 

--- a/curp/src/server/bg_tasks.rs
+++ b/curp/src/server/bg_tasks.rs
@@ -17,9 +17,11 @@ use super::{
 use crate::{
     cmd::{Command, CommandExecutor},
     log::LogEntry,
-    rpc::{self, AppendEntriesRequest, Connect, VoteRequest, WaitSyncedResponse},
+    rpc::{connect::ConnectInterface, AppendEntriesRequest, VoteRequest, WaitSyncedResponse},
     server::{
-        cmd_execute_worker::{execute_worker, CmdExeReceiver, CmdExeSender, N_EXECUTE_WORKERS},
+        cmd_execute_worker::{
+            execute_worker, CmdExeReceiver, CmdExeSender, CmdExeSenderInterface, N_EXECUTE_WORKERS,
+        },
         ServerRole, SpeculativePool, State,
     },
     shutdown::Shutdown,
@@ -32,7 +34,11 @@ const RETRY_TIMEOUT: Duration = Duration::from_millis(800);
 
 /// Run background tasks
 #[allow(clippy::too_many_arguments)] // we call this function once, it's ok
-pub(super) async fn run_bg_tasks<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
+pub(super) async fn run_bg_tasks<
+    C: Command + 'static,
+    CE: 'static + CommandExecutor<C>,
+    Conn: ConnectInterface,
+>(
     state: Arc<RwLock<State<C>>>,
     sync_chan: flume::Receiver<SyncMessage<C>>,
     cmd_executor: CE,
@@ -44,12 +50,11 @@ pub(super) async fn run_bg_tasks<C: Command + 'static, CE: 'static + CommandExec
 ) {
     // establish connection with other servers
     let others = state.read().others.clone();
-    let connects = rpc::try_connect(
-        others,
-        #[cfg(test)]
-        reachable,
-    )
-    .await;
+
+    #[cfg(test)]
+    let connects = Conn::try_connect_test(others, reachable).await;
+    #[cfg(not(test))]
+    let connects = Conn::try_connect(others).await;
 
     // notify when a broadcast of append_entries is needed immediately
     let (ae_trigger, ae_trigger_rx) = mpsc::unbounded_channel::<usize>();
@@ -64,7 +69,7 @@ pub(super) async fn run_bg_tasks<C: Command + 'static, CE: 'static + CommandExec
     let bg_heartbeat_handle = tokio::spawn(bg_heartbeat(connects.clone(), Arc::clone(&state)));
     let bg_get_sync_cmds_handle =
         tokio::spawn(bg_get_sync_cmds(Arc::clone(&state), sync_chan, ae_trigger));
-    let calibrate_handle = tokio::spawn(leader_calibrates_followers(connects, state));
+    let calibrate_handle = tokio::spawn(bg_leader_calibrates_followers(connects, state));
 
     // spawn cmd execute worker
     let bg_exe_worker_handles: Vec<JoinHandle<_>> =
@@ -120,8 +125,8 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(150);
 const RPC_TIMEOUT: Duration = Duration::from_millis(50);
 
 /// Background `append_entries`, only works for the leader
-async fn bg_append_entries<C: Command + 'static>(
-    connects: Vec<Arc<Connect>>,
+async fn bg_append_entries<C: Command + 'static, Conn: ConnectInterface>(
+    connects: Vec<Arc<Conn>>,
     state: Arc<RwLock<State<C>>>,
     mut ae_trigger_rx: mpsc::UnboundedReceiver<usize>,
 ) {
@@ -168,10 +173,10 @@ async fn bg_append_entries<C: Command + 'static>(
 
 /// Send `append_entries` containing a single log to a server
 #[allow(clippy::integer_arithmetic, clippy::indexing_slicing)] // log.len() >= 1 because we have a fake log[0], indexing of `next_index` or `match_index` won't panic because we created an entry when initializing the server state
-async fn send_log_until_succeed<C: Command + 'static>(
+async fn send_log_until_succeed<C: Command + 'static, Conn: ConnectInterface>(
     i: usize,
     req: AppendEntriesRequest,
-    connect: Arc<Connect>,
+    connect: Arc<Conn>,
     state: Arc<RwLock<State<C>>>,
 ) {
     // send log[i] until succeed
@@ -230,8 +235,8 @@ async fn send_log_until_succeed<C: Command + 'static>(
 }
 
 /// Background `append_entries`, only works for the leader
-async fn bg_heartbeat<C: Command + 'static>(
-    connects: Vec<Arc<Connect>>,
+async fn bg_heartbeat<C: Command + 'static, Conn: ConnectInterface>(
+    connects: Vec<Arc<Conn>>,
     state: Arc<RwLock<State<C>>>,
 ) {
     let (role_trigger, hb_reset_trigger) =
@@ -259,7 +264,10 @@ async fn bg_heartbeat<C: Command + 'static>(
 
 /// Send `append_entries` to a server
 #[allow(clippy::integer_arithmetic, clippy::indexing_slicing)] // log.len() >= 1 because we have a fake log[0], indexing of `next_index` or `match_index` won't panic because we created an entry when initializing the server state
-async fn send_heartbeat<C: Command + 'static>(connect: Arc<Connect>, state: Arc<RwLock<State<C>>>) {
+async fn send_heartbeat<C: Command + 'static, Conn: ConnectInterface>(
+    connect: Arc<Conn>,
+    state: Arc<RwLock<State<C>>>,
+) {
     // prepare append_entries request args
     let req = state.map_read(|state_r| {
         let next_index = state_r.next_index[connect.id()];
@@ -291,16 +299,17 @@ async fn send_heartbeat<C: Command + 'static>(connect: Arc<Connect>, state: Arc<
             }
             if !resp.success {
                 let mut state = RwLockUpgradableReadGuard::upgrade(state);
-                *state.next_index.get_mut(connect.id()).unwrap() -= 1;
+                *state.next_index.get_mut(connect.id()).unwrap() =
+                    (resp.commit_index + 1).numeric_cast();
             }
         }
     };
 }
 
 /// Background apply
-async fn bg_apply<C: Command + 'static>(
+async fn bg_apply<C: Command + 'static, Tx: CmdExeSenderInterface<C>>(
     state: Arc<RwLock<State<C>>>,
-    exe_tx: CmdExeSender<C>,
+    exe_tx: Tx,
     spec: Arc<Mutex<SpeculativePool<C>>>,
 ) {
     let (commit_trigger, cmd_board) =
@@ -342,11 +351,11 @@ async fn bg_apply<C: Command + 'static>(
 }
 
 /// The leader handles after sync
-fn handle_after_sync_leader<C: Command + 'static>(
+fn handle_after_sync_leader<C: Command + 'static, Tx: CmdExeSenderInterface<C>>(
     cmd_board: Arc<Mutex<CommandBoard>>,
     cmd: Arc<C>,
     index: LogIndex,
-    exe_tx: &CmdExeSender<C>,
+    exe_tx: &Tx,
 ) {
     let cmd_id = cmd.id().clone();
 
@@ -414,8 +423,8 @@ fn handle_after_sync_leader<C: Command + 'static>(
 }
 
 /// The follower handles after sync
-fn handle_after_sync_follower<C: Command + 'static>(
-    exe_tx: &CmdExeSender<C>,
+fn handle_after_sync_follower<C: Command + 'static, Tx: CmdExeSenderInterface<C>>(
+    exe_tx: &Tx,
     cmd: Arc<C>,
     index: LogIndex,
 ) {
@@ -424,57 +433,18 @@ fn handle_after_sync_follower<C: Command + 'static>(
 }
 
 /// How long a candidate should wait before it starts another round of election
-const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(1);
+const CANDIDATE_TIMEOUT: Duration = Duration::from_secs(3);
 /// How long a follower should wait before it starts a round of election (in millis)
 const FOLLOWER_TIMEOUT: Range<u64> = 1000..2000;
 
 /// Background election
-async fn bg_election<C: Command + 'static>(
-    connects: Vec<Arc<Connect>>,
+async fn bg_election<C: Command + 'static, Conn: ConnectInterface>(
+    connects: Vec<Arc<Conn>>,
     state: Arc<RwLock<State<C>>>,
 ) {
-    let (role_trigger, last_rpc_time) =
-        state.map_read(|state_r| (state_r.role_trigger(), state_r.last_rpc_time()));
+    let last_rpc_time = state.map_read(|state_r| state_r.last_rpc_time());
     loop {
-        // only follower or candidate should run this task
-        while state.read().is_leader() {
-            role_trigger.listen().await;
-        }
-
-        let current_role = state.read().role();
-        let start_vote = match current_role {
-            ServerRole::Follower => {
-                let timeout = Duration::from_millis(thread_rng().gen_range(FOLLOWER_TIMEOUT));
-                // wait until it needs to vote
-                loop {
-                    let next_check = last_rpc_time.read().to_owned() + timeout;
-                    tokio::time::sleep_until(next_check).await;
-                    if Instant::now() - *last_rpc_time.read() > timeout {
-                        break;
-                    }
-                }
-                true
-            }
-            ServerRole::Candidate => loop {
-                let next_check = last_rpc_time.read().to_owned() + CANDIDATE_TIMEOUT;
-                tokio::time::sleep_until(next_check).await;
-                // check election status
-                match state.read().role() {
-                    // election failed, becomes a follower || election succeeded, becomes a leader
-                    ServerRole::Follower | ServerRole::Leader => {
-                        break false;
-                    }
-                    ServerRole::Candidate => {}
-                }
-                if Instant::now() - *last_rpc_time.read() > CANDIDATE_TIMEOUT {
-                    break true;
-                }
-            },
-            ServerRole::Leader => false, // leader should not vote
-        };
-        if !start_vote {
-            continue;
-        }
+        wait_for_election(Arc::clone(&state)).await;
 
         // start election
         #[allow(clippy::integer_arithmetic)] // TODO: handle possible overflow
@@ -506,9 +476,52 @@ async fn bg_election<C: Command + 'static>(
     }
 }
 
+/// wait until an election is needed
+async fn wait_for_election<C: Command + 'static>(state: Arc<RwLock<State<C>>>) {
+    let (role_trigger, last_rpc_time) =
+        state.map_read(|state_r| (state_r.role_trigger(), state_r.last_rpc_time()));
+    'outer: loop {
+        // only follower or candidate should try to elect
+        let role = state.read().role();
+        match role {
+            ServerRole::Follower => {
+                let timeout = Duration::from_millis(thread_rng().gen_range(FOLLOWER_TIMEOUT));
+                // wait until it needs to vote
+                loop {
+                    let next_check = last_rpc_time.read().to_owned() + timeout;
+                    tokio::time::sleep_until(next_check).await;
+                    if Instant::now() - *last_rpc_time.read() > timeout {
+                        break 'outer;
+                    }
+                }
+            }
+            ServerRole::Candidate => 'inner: loop {
+                let next_check = last_rpc_time.read().to_owned() + CANDIDATE_TIMEOUT;
+                tokio::time::sleep_until(next_check).await;
+                // check election status
+                match state.read().role() {
+                    // election failed, becomes a follower || election succeeded, becomes a leader
+                    ServerRole::Follower | ServerRole::Leader => {
+                        break 'inner;
+                    }
+                    ServerRole::Candidate => {}
+                }
+                // another round of election is needed
+                if Instant::now() - *last_rpc_time.read() > CANDIDATE_TIMEOUT {
+                    break 'outer;
+                }
+            },
+            // leader should start election
+            ServerRole::Leader => {
+                role_trigger.listen().await;
+            }
+        };
+    }
+}
+
 /// send vote request
-async fn send_vote<C: Command + 'static>(
-    connect: Arc<Connect>,
+async fn send_vote<C: Command + 'static, Conn: ConnectInterface>(
+    connect: Arc<Conn>,
     state: Arc<RwLock<State<C>>>,
     req: VoteRequest,
 ) {
@@ -560,72 +573,643 @@ async fn send_vote<C: Command + 'static>(
 
 /// Leader should first enforce followers to be consistent with it when it comes to power
 #[allow(clippy::integer_arithmetic, clippy::indexing_slicing)] // log.len() >= 1 because we have a fake log[0], indexing of `next_index` or `match_index` won't panic because we created an entry when initializing the server state
-async fn leader_calibrates_followers<C: Command + 'static>(
-    connects: Vec<Arc<Connect>>,
+async fn bg_leader_calibrates_followers<C: Command + 'static, Conn: ConnectInterface>(
+    connects: Vec<Arc<Conn>>,
     state: Arc<RwLock<State<C>>>,
 ) {
     let calibrate_trigger = Arc::clone(&state.read().calibrate_trigger);
     loop {
         calibrate_trigger.listen().await;
         for connect in connects.clone() {
-            let state = Arc::clone(&state);
-            let _handle = tokio::spawn(async move {
-                loop {
-                    // send append entry
-                    let (req, last_sent_index) = {
-                        let state_r = state.read();
-                        let next_index = state_r.next_index[connect.id()];
-                        match AppendEntriesRequest::new(
-                            state_r.term,
-                            state_r.id().clone(),
-                            next_index - 1,
-                            state_r.log[next_index - 1].term(),
-                            state_r.log[next_index..].to_vec(),
-                            state_r.commit_index,
-                        ) {
-                            Err(e) => {
-                                error!("unable to serialize append entries request: {}", e);
-                                return;
-                            }
-                            Ok(req) => (req, state_r.log.len() - 1),
-                        }
-                    };
-
-                    let resp = connect.append_entries(req, RPC_TIMEOUT).await;
-
-                    #[allow(clippy::unwrap_used)]
-                    // indexing of `next_index` or `match_index` won't panic because we created an entry when initializing the server state
-                    match resp {
-                        Err(e) => {
-                            warn!("append_entries error: {}", e);
-                            tokio::time::sleep(RETRY_TIMEOUT).await;
-                        }
-                        Ok(resp) => {
-                            let resp = resp.into_inner();
-                            // calibrate term
-                            let state = state.upgradable_read();
-                            if resp.term > state.term {
-                                let mut state = RwLockUpgradableReadGuard::upgrade(state);
-                                state.update_to_term(resp.term);
-                                return;
-                            }
-
-                            let mut state = RwLockUpgradableReadGuard::upgrade(state);
-
-                            // successfully calibrate
-                            if resp.success {
-                                *state.next_index.get_mut(connect.id()).unwrap() =
-                                    last_sent_index + 1;
-                                *state.match_index.get_mut(connect.id()).unwrap() = last_sent_index;
-                                break;
-                            }
-
-                            *state.next_index.get_mut(connect.id()).unwrap() =
-                                (resp.commit_index + 1).numeric_cast();
-                        }
-                    };
-                }
-            });
+            let _handle = tokio::spawn(leader_calibrates_follower(connect, Arc::clone(&state)));
         }
+    }
+}
+
+/// Leader calibrates a follower
+#[allow(clippy::integer_arithmetic, clippy::indexing_slicing)] // log.len() >= 1 because we have a fake log[0], indexing of `next_index` or `match_index` won't panic because we created an entry when initializing the server state
+async fn leader_calibrates_follower<C: Command + 'static, Conn: ConnectInterface>(
+    connect: Arc<Conn>,
+    state: Arc<RwLock<State<C>>>,
+) {
+    loop {
+        // send append entry
+        let (req, last_sent_index) = {
+            let state_r = state.read();
+            let next_index = state_r.next_index[connect.id()];
+            match AppendEntriesRequest::new(
+                state_r.term,
+                state_r.id().clone(),
+                next_index - 1,
+                state_r.log[next_index - 1].term(),
+                state_r.log[next_index..].to_vec(),
+                state_r.commit_index,
+            ) {
+                Err(e) => {
+                    error!("unable to serialize append entries request: {}", e);
+                    return;
+                }
+                Ok(req) => (req, state_r.log.len() - 1),
+            }
+        };
+
+        let resp = connect.append_entries(req, RPC_TIMEOUT).await;
+
+        #[allow(clippy::unwrap_used)]
+        // indexing of `next_index` or `match_index` won't panic because we created an entry when initializing the server state
+        match resp {
+            Err(e) => {
+                warn!("append_entries error: {}", e);
+                tokio::time::sleep(RETRY_TIMEOUT).await;
+            }
+            Ok(resp) => {
+                let resp = resp.into_inner();
+                // calibrate term
+                let state = state.upgradable_read();
+                if resp.term > state.term {
+                    let mut state = RwLockUpgradableReadGuard::upgrade(state);
+                    state.update_to_term(resp.term);
+                    return;
+                }
+
+                let mut state = RwLockUpgradableReadGuard::upgrade(state);
+
+                // successfully calibrate
+                if resp.success {
+                    *state.next_index.get_mut(connect.id()).unwrap() = last_sent_index + 1;
+                    *state.match_index.get_mut(connect.id()).unwrap() = last_sent_index;
+                    break;
+                }
+
+                *state.next_index.get_mut(connect.id()).unwrap() =
+                    (resp.commit_index + 1).numeric_cast();
+            }
+        };
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{collections::HashMap, sync::Arc};
+
+    use parking_lot::{Mutex, RwLock};
+    use tokio::{sync::oneshot, time::Instant};
+    use tracing_test::traced_test;
+
+    use super::*;
+    use crate::{
+        cmd::Command,
+        error::ProposeError,
+        log::LogEntry,
+        rpc::{
+            connect::MockConnectInterface, AppendEntriesRequest, AppendEntriesResponse, SyncResult,
+            VoteRequest, VoteResponse,
+        },
+        server::{
+            bg_tasks::send_log_until_succeed, cmd_board::CommandBoard,
+            cmd_execute_worker::MockCmdExeSenderInterface, state::State, ServerRole,
+        },
+        test_utils::{sleep_millis, sleep_secs, test_cmd::TestCommand},
+    };
+
+    const LEADER_ID: &str = "test-leader";
+    const FOLLOWER_ID1: &str = "test-follower-1";
+    const FOLLOWER_ID2: &str = "test-follower-2";
+
+    fn new_test_state() -> Arc<RwLock<State<TestCommand>>> {
+        let others = HashMap::from([
+            (FOLLOWER_ID1.to_owned(), "127.0.0.1:8001".to_owned()),
+            (FOLLOWER_ID2.to_owned(), "127.0.0.1:8002".to_owned()),
+        ]);
+        Arc::new(RwLock::new(State::new(
+            LEADER_ID.to_owned(),
+            ServerRole::Leader,
+            others,
+            Arc::new(Mutex::new(CommandBoard::new())),
+            Arc::new(RwLock::new(Instant::now())),
+        )))
+    }
+
+    /*************** tests for send_log_until_succeed **************/
+
+    #[traced_test]
+    #[tokio::test]
+    async fn logs_will_be_resent() {
+        let state = new_test_state();
+
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect
+            .expect_append_entries()
+            .times(4)
+            .returning(|_, _| Err(ProposeError::RpcStatus("timeout".to_owned())));
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        let handle = tokio::spawn(async move {
+            let req = AppendEntriesRequest::new(
+                1,
+                LEADER_ID.to_owned(),
+                0,
+                0,
+                vec![LogEntry::new(1, &[Arc::new(TestCommand::default())])],
+                0,
+            )
+            .unwrap();
+            send_log_until_succeed(1, req, Arc::new(mock_connect), state).await;
+        });
+        sleep_secs(3).await;
+        assert!(!handle.is_finished());
+        handle.abort();
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn send_log_will_stop_after_new_election() {
+        let state = new_test_state();
+
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect.expect_append_entries().returning(|_, _| {
+            Ok(tonic::Response::new(AppendEntriesResponse::new_reject(
+                2, 0,
+            )))
+        });
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        let state_c = Arc::clone(&state);
+        let handle = tokio::spawn(async move {
+            let req = AppendEntriesRequest::new(
+                1,
+                LEADER_ID.to_owned(),
+                0,
+                0,
+                vec![LogEntry::new(1, &[Arc::new(TestCommand::default())])],
+                0,
+            )
+            .unwrap();
+            send_log_until_succeed(1, req, Arc::new(mock_connect), state_c).await;
+        });
+
+        assert!(handle.await.is_ok());
+        assert_eq!(state.read().term, 2);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn send_log_will_succeed_and_commit() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state
+                .log
+                .push(LogEntry::new(0, &[Arc::new(TestCommand::default())]));
+            let match_index = state.match_index.get_mut(FOLLOWER_ID1).unwrap();
+            *match_index = 0;
+            *state.next_index.get_mut(FOLLOWER_ID1).unwrap() = *match_index + 1;
+        }
+
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect
+            .expect_append_entries()
+            .returning(|_, _| Ok(tonic::Response::new(AppendEntriesResponse::new_accept(0))));
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+        let state_c = Arc::clone(&state);
+        let handle = tokio::spawn(async move {
+            let req = AppendEntriesRequest::new(
+                1,
+                LEADER_ID.to_owned(),
+                0,
+                0,
+                vec![LogEntry::new(1, &[Arc::new(TestCommand::default())])],
+                0,
+            )
+            .unwrap();
+            send_log_until_succeed(1, req, Arc::new(mock_connect), state_c).await;
+        });
+
+        assert!(handle.await.is_ok());
+        assert_eq!(state.read().term, 0);
+        assert_eq!(state.read().commit_index, 1);
+        assert_eq!(state.read().match_index[FOLLOWER_ID1], 1);
+        assert_eq!(state.read().next_index[FOLLOWER_ID1], 2);
+    }
+
+    /*************** tests for send_heartbeat **************/
+
+    #[traced_test]
+    #[tokio::test]
+    async fn send_heartbeat_will_calibrate_term() {
+        let state = new_test_state();
+
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect.expect_append_entries().returning(|_, _| {
+            Ok(tonic::Response::new(AppendEntriesResponse::new_reject(
+                1, 0,
+            )))
+        });
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        send_heartbeat(Arc::new(mock_connect), Arc::clone(&state)).await;
+
+        let state = state.read();
+        assert_eq!(state.term, 1);
+        assert_eq!(state.role(), ServerRole::Follower);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn send_heartbeat_will_calibrate_next_index() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state
+                .log
+                .push(LogEntry::new(0, &[Arc::new(TestCommand::default())]));
+            *state.next_index.get_mut(FOLLOWER_ID1).unwrap() = 2;
+        }
+
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect.expect_append_entries().returning(|_, _| {
+            Ok(tonic::Response::new(AppendEntriesResponse::new_reject(
+                0, 0,
+            )))
+        });
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        send_heartbeat(Arc::new(mock_connect), Arc::clone(&state)).await;
+
+        let state = state.read();
+        assert_eq!(state.term, 0);
+        assert_eq!(state.next_index[FOLLOWER_ID1], 1);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn no_heartbeat_when_contention_is_high() {
+        let state = new_test_state();
+        let hb_reset_trigger = state.read().heartbeat_reset_trigger();
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect.expect_append_entries().never();
+
+        let connects = vec![Arc::new(mock_connect)];
+        let handle = tokio::spawn(async move {
+            bg_heartbeat(connects, state).await;
+        });
+
+        for _ in 0..50 {
+            sleep_millis(50).await;
+            hb_reset_trigger.notify(1);
+        }
+
+        handle.abort();
+    }
+
+    /*************** tests for bg_apply **************/
+
+    #[traced_test]
+    #[tokio::test]
+    // this test will apply 2 log: one needs execution, the other doesn't
+    async fn leader_will_apply_logs_after_commit() {
+        let state = new_test_state();
+        let mut spec = SpeculativePool::new();
+        let (id1, id2) = {
+            let mut state = state.write();
+            let cmd_board = state.cmd_board();
+            let mut cmd_board = cmd_board.lock();
+
+            let cmd1 = TestCommand::new_get(vec![1]);
+            let id1 = cmd1.id().clone();
+            spec.push(cmd1.clone());
+            cmd_board
+                .cmd_states
+                .insert(cmd1.id().clone(), CmdState::Execute);
+            state.log.push(LogEntry::new(0, &[Arc::new(cmd1)]));
+
+            let cmd2 = TestCommand::default();
+            let id2 = cmd2.id().clone();
+            spec.push(cmd2.clone());
+            cmd_board
+                .cmd_states
+                .insert(cmd2.id().clone(), CmdState::AfterSync);
+            state.log.push(LogEntry::new(0, &[Arc::new(cmd2)]));
+
+            state.commit_index = 2;
+            (id1, id2)
+        };
+        let spec = Arc::new(Mutex::new(spec));
+
+        let mut exe_tx = MockCmdExeSenderInterface::default();
+        let id1_c = id1.clone();
+        exe_tx
+            .expect_send_exe_and_after_sync()
+            .return_once(move |cmd: Arc<TestCommand>, index| {
+                assert_eq!(cmd.id(), &id1_c);
+                assert_eq!(index, 1);
+                let (tx, rx) = oneshot::channel();
+                tx.send((Ok(vec![]), Some(Ok(1)))).unwrap();
+                rx
+            });
+        let id2_c = id2.clone();
+        exe_tx
+            .expect_send_after_sync()
+            .return_once(move |cmd: Arc<TestCommand>, index| {
+                assert_eq!(cmd.id(), &id2_c);
+                assert_eq!(index, 2);
+                let (tx, rx) = oneshot::channel();
+                tx.send(Ok(2)).unwrap();
+                rx
+            });
+
+        let (state_c, spec_c) = (Arc::clone(&state), Arc::clone(&spec));
+        let handle = tokio::spawn(async move {
+            bg_apply(state_c, exe_tx, spec_c).await;
+        });
+
+        sleep_millis(500).await;
+
+        // check
+        let state = state.read();
+        let cmd_board = state.cmd_board();
+        let mut cmd_board = cmd_board.lock();
+        let spec = spec.lock();
+
+        let resp1 = cmd_board.cmd_states.remove(&id1).unwrap();
+        let resp1: SyncResult<TestCommand> = match resp1 {
+            CmdState::FinalResponse(resp1) => resp1.unwrap().into().unwrap(),
+            _ => panic!(),
+        };
+        match resp1 {
+            SyncResult::Success { er, asr } => {
+                assert!(er.is_some());
+                assert_eq!(asr, 1);
+            }
+            _ => panic!(),
+        }
+
+        let resp2 = cmd_board.cmd_states.remove(&id2).unwrap();
+        let resp2: SyncResult<TestCommand> = match resp2 {
+            CmdState::FinalResponse(resp2) => resp2.unwrap().into().unwrap(),
+            _ => panic!(),
+        };
+        match resp2 {
+            SyncResult::Success { er, asr } => {
+                assert!(er.is_none());
+                assert_eq!(asr, 2);
+            }
+            _ => panic!(),
+        }
+
+        assert!(spec.pool.is_empty());
+        assert!(spec.ready.is_empty());
+        assert_eq!(state.last_applied, 2);
+
+        handle.abort();
+    }
+
+    /*************** tests for election **************/
+
+    #[traced_test]
+    #[tokio::test]
+    async fn follower_will_not_start_election_when_heartbeats_are_received() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state.set_role(ServerRole::Follower);
+        }
+        let last_rpc_time = state.read().last_rpc_time();
+
+        let handle = tokio::spawn(wait_for_election(state));
+
+        for _ in 0..20 {
+            sleep_millis(150).await;
+            *last_rpc_time.write() = Instant::now();
+        }
+
+        assert!(!handle.is_finished());
+        handle.abort();
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn follower_will_start_election_when_no_heartbeats() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state.set_role(ServerRole::Follower);
+        }
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(3), wait_for_election(state))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn candidate_will_start_another_round_of_election_if_not_succeed() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state.set_role(ServerRole::Candidate);
+        }
+
+        assert!(
+            tokio::time::timeout(Duration::from_secs(4), wait_for_election(state))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn candidate_will_not_start_election_if_it_becomes_leader() {
+        let state = new_test_state();
+        let last_rpc_time = state.read().last_rpc_time();
+        {
+            let mut state = state.write();
+            state.set_role(ServerRole::Candidate);
+        }
+        let handle = tokio::spawn(wait_for_election(Arc::clone(&state)));
+        let hb_handle = tokio::spawn(async move {
+            for _ in 0..20 {
+                sleep_millis(150).await;
+                *last_rpc_time.write() = Instant::now();
+            }
+        });
+
+        sleep_secs(1).await;
+
+        {
+            let mut state = state.write();
+            state.set_role(ServerRole::Leader);
+        }
+
+        hb_handle.await.unwrap();
+        assert!(!handle.is_finished());
+        handle.abort();
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn candidate_will_not_start_election_if_it_becomes_follower() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state.set_role(ServerRole::Candidate);
+        }
+        let handle = tokio::spawn(wait_for_election(Arc::clone(&state)));
+
+        sleep_secs(1).await;
+
+        {
+            let mut state = state.write();
+            state.set_role(ServerRole::Follower);
+        }
+
+        assert!(!handle.is_finished());
+        handle.abort();
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn vote_will_calibrate_term() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state.update_to_term(1);
+            state.set_role(ServerRole::Candidate);
+            state.voted_for = Some(state.id().clone());
+            state.votes_received = 1;
+        }
+
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect
+            .expect_vote()
+            .returning(|_, _| Ok(tonic::Response::new(VoteResponse::new_reject(2))));
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        let req = VoteRequest::new(2, FOLLOWER_ID1.to_owned(), 0, 0);
+        send_vote(Arc::new(mock_connect), Arc::clone(&state), req).await;
+
+        let state = state.read();
+        assert_eq!(state.term, 2);
+        assert_eq!(state.role(), ServerRole::Follower);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn candidate_will_become_leader_after_election_succeeds() {
+        let state = new_test_state();
+        {
+            // start election
+            let mut state = state.write();
+            state.update_to_term(1);
+            state.set_role(ServerRole::Candidate);
+            state.voted_for = Some(state.id().clone());
+            state.votes_received = 1;
+        }
+
+        let mut mock_connect1 = MockConnectInterface::default();
+        mock_connect1
+            .expect_vote()
+            .returning(|_, _| Ok(tonic::Response::new(VoteResponse::new_accept(1))));
+        mock_connect1
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        let mut mock_connect2 = MockConnectInterface::default();
+        mock_connect2
+            .expect_vote()
+            .returning(|_, _| Ok(tonic::Response::new(VoteResponse::new_accept(1))));
+        mock_connect2
+            .expect_id()
+            .return_const(FOLLOWER_ID2.to_owned());
+
+        let req = VoteRequest::new(2, FOLLOWER_ID1.to_owned(), 0, 0);
+
+        send_vote(Arc::new(mock_connect1), Arc::clone(&state), req.clone()).await;
+        {
+            let state = state.read();
+            assert_eq!(state.term, 1);
+            assert_eq!(state.role(), ServerRole::Leader);
+        }
+
+        send_vote(Arc::new(mock_connect2), Arc::clone(&state), req.clone()).await;
+
+        let state = state.read();
+        assert_eq!(state.term, 1);
+        assert_eq!(state.role(), ServerRole::Leader);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn leader_will_calibrate_follower_until_succeed() {
+        let state = new_test_state();
+        {
+            let mut state = state.write();
+            state
+                .log
+                .push(LogEntry::new(0, &[Arc::new(TestCommand::default())]));
+            state
+                .log
+                .push(LogEntry::new(0, &[Arc::new(TestCommand::default())]));
+            let next_index = state.next_index.get_mut(FOLLOWER_ID1).unwrap();
+            *next_index = 3;
+        }
+
+        let mut mock_connect = MockConnectInterface::default();
+        let mut call_cnt = 0;
+        mock_connect.expect_append_entries().returning(move |_, _| {
+            call_cnt += 1;
+            match call_cnt {
+                1 => Ok(tonic::Response::new(AppendEntriesResponse::new_reject(
+                    0, 0,
+                ))),
+                _ => Ok(tonic::Response::new(AppendEntriesResponse::new_accept(0))),
+            }
+        });
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        leader_calibrates_follower(Arc::new(mock_connect), Arc::clone(&state)).await;
+        {
+            let state = state.read();
+            assert_eq!(state.next_index[FOLLOWER_ID1], 3);
+            assert_eq!(state.match_index[FOLLOWER_ID1], 2);
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn leader_calibrate_follower_will_calibrate_term() {
+        let state = new_test_state();
+
+        let mut mock_connect = MockConnectInterface::default();
+        mock_connect.expect_append_entries().returning(|_, _| {
+            Ok(tonic::Response::new(AppendEntriesResponse::new_reject(
+                1, 0,
+            )))
+        });
+        mock_connect
+            .expect_id()
+            .return_const(FOLLOWER_ID1.to_owned());
+
+        leader_calibrates_follower(Arc::new(mock_connect), Arc::clone(&state)).await;
+
+        let state = state.read();
+        assert_eq!(state.term, 1);
+        assert_eq!(state.role(), ServerRole::Follower);
     }
 }

--- a/curp/src/server/cmd_board.rs
+++ b/curp/src/server/cmd_board.rs
@@ -45,6 +45,14 @@ impl<C: Command> CommandBoard<C> {
             .for_each(|(_, event)| event.notify(usize::MAX));
     }
 
+    /// Clear
+    pub(super) fn clear(&mut self) {
+        self.needs_exe.clear();
+        self.er_buffer.clear();
+        self.asr_buffer.clear();
+        self.release_notifiers();
+    }
+
     /// Insert er to internal buffer
     pub(super) fn insert_er(&mut self, id: &ProposeId, er: Result<C::ER, ExecuteError>) {
         let er_ok = er.is_ok();

--- a/curp/src/server/cmd_board.rs
+++ b/curp/src/server/cmd_board.rs
@@ -1,25 +1,40 @@
-use std::collections::HashMap;
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use event_listener::Event;
 use indexmap::IndexMap;
+use parking_lot::RwLock;
 
-use crate::{cmd::ProposeId, rpc::WaitSyncedResponse};
+use crate::{
+    cmd::{Command, ProposeId},
+    error::ExecuteError,
+};
 
-/// Command board is a buffer to store command execution result for `wait_synced` requests
-// TODO: GC
-pub(super) struct CommandBoard {
-    /// Stores all notifiers for wait_synced requests
+/// Ref to the cmd board
+pub(super) type CmdBoardRef<C> = Arc<RwLock<CommandBoard<C>>>;
+
+/// Command board is a buffer to track cmd states and store notifiers for requests that need to wait for a cmd
+pub(super) struct CommandBoard<C: Command> {
+    /// Store all notifiers for wait_synced requests
     pub(super) notifiers: HashMap<ProposeId, Event>,
-    /// Stores all command states
-    pub(super) cmd_states: IndexMap<ProposeId, CmdState>,
+    /// Whether the cmd needs execution when after sync
+    pub(super) needs_exe: HashSet<ProposeId>,
+    /// Store all execution results
+    pub(super) er_buffer: IndexMap<ProposeId, Result<C::ER, ExecuteError>>,
+    /// Store all after sync results
+    pub(super) asr_buffer: IndexMap<ProposeId, Result<C::ASR, ExecuteError>>,
 }
 
-impl CommandBoard {
+impl<C: Command> CommandBoard<C> {
     /// Create an empty command board
     pub(super) fn new() -> Self {
         Self {
             notifiers: HashMap::new(),
-            cmd_states: IndexMap::new(),
+            needs_exe: HashSet::new(),
+            er_buffer: IndexMap::new(),
+            asr_buffer: IndexMap::new(),
         }
     }
 
@@ -29,19 +44,34 @@ impl CommandBoard {
             .drain()
             .for_each(|(_, event)| event.notify(usize::MAX));
     }
-}
 
-/// The state of a command in cmd watch board
-/// (`EarlyArrive` -> ) `Execute` -> `AfterSync` -> `FinalResponse`
-// TODO: this struct might be removed. We don't need to store whether the command needs execution after sync in one place. We can attach it to SyncMessage.
-#[derive(Debug)]
-pub(super) enum CmdState {
-    /// Request for cmd sync result arrives earlier than the cmd itself
-    EarlyArrive,
-    /// Command still needs execute
-    Execute,
-    /// Command still needs not execute
-    AfterSync,
-    /// Command gotten the final result
-    FinalResponse(Result<WaitSyncedResponse, bincode::Error>),
+    /// Insert er to internal buffer
+    pub(super) fn insert_er(&mut self, id: &ProposeId, er: Result<C::ER, ExecuteError>) {
+        let er_ok = er.is_ok();
+        assert!(
+            self.er_buffer.insert(id.clone(), er).is_none(),
+            "er should not be inserted twice"
+        );
+
+        if !er_ok {
+            self.notify(id);
+        }
+    }
+
+    /// Insert er to internal buffer
+    pub(super) fn insert_asr(&mut self, id: &ProposeId, asr: Result<C::ASR, ExecuteError>) {
+        assert!(
+            self.asr_buffer.insert(id.clone(), asr).is_none(),
+            "er should not be inserted twice"
+        );
+
+        self.notify(id);
+    }
+
+    /// Notify `wait_synced` requests
+    pub(super) fn notify(&self, id: &ProposeId) {
+        if let Some(notifier) = self.notifiers.get(id) {
+            notifier.notify(usize::MAX);
+        }
+    }
 }

--- a/curp/src/server/cmd_execute_worker.rs
+++ b/curp/src/server/cmd_execute_worker.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use futures::future::OptionFuture;
+use lock_utils::parking_lot_lock::RwLockMap;
 #[cfg(test)]
 use mockall::automock;
 use tokio::sync::oneshot;
@@ -12,6 +12,7 @@ use crate::{
     conflict_checked_mpmc,
     conflict_checked_mpmc::{ConflictCheckedMsg, DoneNotifier},
     error::ExecuteError,
+    server::cmd_board::CmdBoardRef,
     LogIndex,
 };
 
@@ -21,32 +22,61 @@ pub(super) const N_EXECUTE_WORKERS: usize = 8;
 /// Worker that execute commands
 pub(super) async fn execute_worker<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
     dispatch_rx: CmdExeReceiver<C>,
+    cmd_board: CmdBoardRef<C>,
     ce: Arc<CE>,
 ) {
     while let Ok((ExecuteMessage { cmd, er_tx }, done)) = dispatch_rx.recv().await {
         match er_tx {
-            ExeResultSender::Execute(tx) => {
-                let er = cmd.execute(ce.as_ref()).await;
+            ExecuteMessageType::Execute(tx) => {
+                let er = ce.execute(cmd.as_ref()).await;
                 debug!("cmd {:?} is executed", cmd.id());
+                cmd_board.write().insert_er(cmd.id(), er.clone()); // insert er
                 let _ignore = tx.send(er); // it's ok to ignore the result here because sometimes the result is not needed
             }
-            ExeResultSender::AfterSync(tx, index) => {
-                let asr = cmd.after_sync(ce.as_ref(), index).await;
-                debug!("cmd {:?} after sync is called", cmd.id());
-                let _ignore = tx.send(asr); // it's ok to ignore the result here because sometimes the result is not needed
-            }
-            ExeResultSender::ExecuteAndAfterSync(tx, index) => {
-                let er = cmd.execute(ce.as_ref()).await;
-                debug!("cmd {:?} is executed", cmd.id());
-                let asr: OptionFuture<_> = er
-                    .is_ok()
-                    .then(|| async {
-                        let asr = cmd.after_sync(ce.as_ref(), index).await;
+            ExecuteMessageType::AfterSync(index) => {
+                /// Different conditions in after sync
+                enum Condition {
+                    /// Call both exe and after sync
+                    ExeAndAfterSync,
+                    /// Call after sync only
+                    AfterSync,
+                    /// Do nothing
+                    Nothing,
+                }
+                let condition = cmd_board.map_write(|mut board_w| {
+                    #[allow(clippy::unwrap_used)]
+                    // We can unwrap here because ExecuteMessage::AfterSync must arrive later than ExecuteMessage::Execute because a cmd conflicts itself
+                    if board_w.needs_exe.remove(cmd.id()) {
+                        // The cmd needs both execution and after sync
+                        Condition::ExeAndAfterSync
+                    } else if board_w.er_buffer.get(cmd.id()).unwrap().is_ok() {
+                        // execution succeeded, we can do call after sync now
+                        Condition::AfterSync
+                    } else {
+                        Condition::Nothing
+                    }
+                });
+
+                match condition {
+                    Condition::ExeAndAfterSync => {
+                        let er = ce.execute(cmd.as_ref()).await;
+                        let er_ok = er.is_ok();
+                        cmd_board.write().insert_er(cmd.id(), er);
+                        debug!("cmd {:?} is executed", cmd.id());
+
+                        if er_ok {
+                            let asr = ce.after_sync(cmd.as_ref(), index).await;
+                            cmd_board.write().insert_asr(cmd.id(), asr);
+                            debug!("cmd {:?} after sync is called", cmd.id());
+                        }
+                    }
+                    Condition::AfterSync => {
+                        let asr = ce.after_sync(cmd.as_ref(), index).await;
+                        cmd_board.write().insert_asr(cmd.id(), asr);
                         debug!("cmd {:?} after sync is called", cmd.id());
-                        asr
-                    })
-                    .into();
-                let _ignore = tx.send((er, asr.await)); // it's ok to ignore the result here because sometimes the result is not needed
+                    }
+                    Condition::Nothing => {}
+                }
             }
         }
         if let Err(e) = done.notify() {
@@ -61,7 +91,7 @@ struct ExecuteMessage<C: Command + 'static> {
     /// The cmd to be executed
     cmd: Arc<C>,
     /// Send execution result
-    er_tx: ExeResultSender<C>,
+    er_tx: ExecuteMessageType<C>,
 }
 
 impl<C: Command + 'static> ConflictCheckedMsg for ExecuteMessage<C> {
@@ -74,26 +104,17 @@ impl<C: Command + 'static> ConflictCheckedMsg for ExecuteMessage<C> {
 
 impl<C: Command + 'static> ExecuteMessage<C> {
     /// Create a new exe msg
-    fn new(cmd: Arc<C>, er_tx: ExeResultSender<C>) -> Self {
+    fn new(cmd: Arc<C>, er_tx: ExecuteMessageType<C>) -> Self {
         Self { cmd, er_tx }
     }
 }
 
-/// Channel for transferring execution results
-enum ExeResultSender<C: Command + 'static> {
+/// Type of execute message
+enum ExecuteMessageType<C: Command + 'static> {
     /// Only call `execute`
     Execute(oneshot::Sender<Result<C::ER, ExecuteError>>),
-    /// Only call `after_sync`
-    AfterSync(oneshot::Sender<Result<C::ASR, ExecuteError>>, LogIndex),
-    /// Call both `execute` and `after_sync`
-    #[allow(clippy::type_complexity)] // though complex, it's quite clear
-    ExecuteAndAfterSync(
-        oneshot::Sender<(
-            Result<C::ER, ExecuteError>,
-            Option<Result<C::ASR, ExecuteError>>, // why option: if execution fails, after sync will not be called
-        )>,
-        LogIndex,
-    ),
+    /// After sync is ready to be called
+    AfterSync(LogIndex),
 }
 
 /// Send cmd to background execute cmd task
@@ -112,66 +133,25 @@ pub(super) trait CmdExeSenderInterface<C: Command> {
     /// Send cmd to background cmd executor and return a oneshot receiver for the execution result
     fn send_exe(&self, cmd: Arc<C>) -> oneshot::Receiver<Result<C::ER, ExecuteError>>;
 
-    /// Send cmd to background cmd executor and return a oneshot receiver for the execution result
-    fn send_after_sync(
-        &self,
-        cmd: Arc<C>,
-        index: LogIndex,
-    ) -> oneshot::Receiver<Result<C::ASR, ExecuteError>>;
-
-    /// Send cmd to background cmd executor and return a oneshot receiver for the execution result
-    #[allow(clippy::type_complexity)] // though complex, it's quite clear
-    fn send_exe_and_after_sync(
-        &self,
-        cmd: Arc<C>,
-        index: LogIndex,
-    ) -> oneshot::Receiver<(
-        Result<C::ER, ExecuteError>,
-        Option<Result<C::ASR, ExecuteError>>,
-    )>;
+    /// Send after sync event to the background cmd executor so that after sync can be called
+    fn send_after_sync(&self, cmd: Arc<C>, index: LogIndex);
 }
 
 impl<C: Command + 'static> CmdExeSenderInterface<C> for CmdExeSender<C> {
-    /// Send cmd to background cmd executor and return a oneshot receiver for the execution result
     fn send_exe(&self, cmd: Arc<C>) -> oneshot::Receiver<Result<C::ER, ExecuteError>> {
         let (tx, rx) = oneshot::channel();
-        let msg = ExecuteMessage::new(cmd, ExeResultSender::Execute(tx));
+        let msg = ExecuteMessage::new(cmd, ExecuteMessageType::Execute(tx));
         if let Err(e) = self.0.send(msg) {
             warn!("failed to send cmd to background execute cmd task, {e}");
         }
         rx
     }
 
-    /// Send cmd to background cmd executor and return a oneshot receiver for the execution result
-    fn send_after_sync(
-        &self,
-        cmd: Arc<C>,
-        index: LogIndex,
-    ) -> oneshot::Receiver<Result<C::ASR, ExecuteError>> {
-        let (tx, rx) = oneshot::channel();
-        let msg = ExecuteMessage::new(cmd, ExeResultSender::AfterSync(tx, index));
+    fn send_after_sync(&self, cmd: Arc<C>, index: LogIndex) {
+        let msg = ExecuteMessage::new(cmd, ExecuteMessageType::AfterSync(index));
         if let Err(e) = self.0.send(msg) {
             warn!("failed to send cmd to background execute cmd task, {e}");
         }
-        rx
-    }
-
-    /// Send cmd to background cmd executor and return a oneshot receiver for the execution result
-    #[allow(clippy::type_complexity)] // though complex, it's quite clear
-    fn send_exe_and_after_sync(
-        &self,
-        cmd: Arc<C>,
-        index: LogIndex,
-    ) -> oneshot::Receiver<(
-        Result<C::ER, ExecuteError>,
-        Option<Result<C::ASR, ExecuteError>>,
-    )> {
-        let (tx, rx) = oneshot::channel();
-        let msg = ExecuteMessage::new(cmd, ExeResultSender::ExecuteAndAfterSync(tx, index));
-        if let Err(e) = self.0.send(msg) {
-            warn!("failed to send cmd to background execute cmd task, {e}");
-        }
-        rx
     }
 }
 
@@ -195,4 +175,147 @@ impl<C: Command + 'static> CmdExeReceiverInterface<C> for CmdExeReceiver<C> {
 pub(super) fn cmd_exe_channel<C: Command + 'static>() -> (CmdExeSender<C>, CmdExeReceiver<C>) {
     let (tx, rx) = conflict_checked_mpmc::channel();
     (CmdExeSender(tx), CmdExeReceiver(rx))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use parking_lot::RwLock;
+    use tokio::{sync::mpsc, time::Instant};
+    use tracing_test::traced_test;
+
+    use super::*;
+    use crate::{
+        server::cmd_board::CommandBoard,
+        test_utils::{
+            sleep_millis, sleep_secs,
+            test_cmd::{TestCE, TestCommand},
+        },
+    };
+
+    // This should happen in fast path in most cases
+    #[traced_test]
+    #[tokio::test]
+    async fn fast_path_normal() {
+        let (er_tx, mut er_rx) = mpsc::unbounded_channel();
+        let (as_tx, mut as_rx) = mpsc::unbounded_channel();
+        let ce = TestCE::new("S1".to_owned(), er_tx, as_tx);
+        let (exe_tx, exe_rx) = cmd_exe_channel::<TestCommand>();
+        let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
+        tokio::spawn(execute_worker(exe_rx, Arc::clone(&cmd_board), Arc::new(ce)));
+
+        let cmd = Arc::new(TestCommand::default());
+        exe_tx.send_exe(Arc::clone(&cmd));
+        assert_eq!(er_rx.recv().await.unwrap().1, vec![]);
+
+        exe_tx.send_after_sync(Arc::clone(&cmd), 1);
+        assert_eq!(as_rx.recv().await.unwrap().1, 1);
+    }
+
+    // When the execution takes more time than sync, as should be called after exe has finished
+    #[traced_test]
+    #[tokio::test]
+    async fn fast_path_cond1() {
+        let (er_tx, mut er_rx) = mpsc::unbounded_channel();
+        let (as_tx, mut as_rx) = mpsc::unbounded_channel();
+        let ce = Arc::new(TestCE::new("S1".to_owned(), er_tx, as_tx));
+        let (exe_tx, exe_rx) = cmd_exe_channel::<TestCommand>();
+        let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
+        tokio::spawn(execute_worker(
+            exe_rx.clone(),
+            Arc::clone(&cmd_board),
+            Arc::clone(&ce),
+        ));
+
+        let begin = Instant::now();
+        let cmd = Arc::new(TestCommand::default().set_exe_dur(Duration::from_secs(1)));
+        exe_tx.send_exe(Arc::clone(&cmd));
+
+        // at 500ms, sync has completed, call after sync, this will be dispatched to the second exe_worker
+        sleep_millis(500).await;
+        exe_tx.send_after_sync(Arc::clone(&cmd), 1);
+
+        assert_eq!(er_rx.recv().await.unwrap().1, vec![]);
+        assert_eq!(as_rx.recv().await.unwrap().1, 1);
+
+        assert!((Instant::now() - begin) >= Duration::from_secs(1));
+    }
+
+    // When the execution takes more time than sync and fails, as should not be called
+    #[traced_test]
+    #[tokio::test]
+    async fn fast_path_cond2() {
+        let (er_tx, mut er_rx) = mpsc::unbounded_channel();
+        let (as_tx, mut as_rx) = mpsc::unbounded_channel();
+        let ce = Arc::new(TestCE::new("S1".to_owned(), er_tx, as_tx));
+        let (exe_tx, exe_rx) = cmd_exe_channel::<TestCommand>();
+        let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
+        tokio::spawn(execute_worker(
+            exe_rx.clone(),
+            Arc::clone(&cmd_board),
+            Arc::clone(&ce),
+        ));
+
+        let cmd = Arc::new(
+            TestCommand::default()
+                .set_exe_dur(Duration::from_secs(1))
+                .set_exe_should_fail(),
+        );
+        exe_tx.send_exe(Arc::clone(&cmd));
+
+        // at 500ms, sync has completed
+        sleep_millis(500).await;
+        exe_tx.send_after_sync(Arc::clone(&cmd), 1);
+
+        // at 1500ms, as should not be called
+        sleep_secs(1).await;
+        assert!(er_rx.try_recv().is_err());
+        assert!(as_rx.try_recv().is_err());
+    }
+
+    // This should happen in slow path in most cases
+    #[traced_test]
+    #[tokio::test]
+    async fn slow_path_normal() {
+        let (er_tx, mut er_rx) = mpsc::unbounded_channel();
+        let (as_tx, mut as_rx) = mpsc::unbounded_channel();
+        let ce = TestCE::new("S1".to_owned(), er_tx, as_tx);
+        let (exe_tx, exe_rx) = cmd_exe_channel::<TestCommand>();
+        let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
+        tokio::spawn(execute_worker(exe_rx, Arc::clone(&cmd_board), Arc::new(ce)));
+
+        let cmd = Arc::new(TestCommand::default());
+        {
+            cmd_board.write().needs_exe.insert(cmd.id().clone());
+        }
+
+        exe_tx.send_after_sync(Arc::clone(&cmd), 1);
+
+        assert_eq!(er_rx.recv().await.unwrap().1, vec![]);
+        assert_eq!(as_rx.recv().await.unwrap().1, 1);
+    }
+
+    // When exe fails
+    #[traced_test]
+    #[tokio::test]
+    async fn slow_path_exe_fails() {
+        let (er_tx, mut er_rx) = mpsc::unbounded_channel();
+        let (as_tx, mut as_rx) = mpsc::unbounded_channel();
+        let ce = TestCE::new("S1".to_owned(), er_tx, as_tx);
+        let (exe_tx, exe_rx) = cmd_exe_channel::<TestCommand>();
+        let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
+        tokio::spawn(execute_worker(exe_rx, Arc::clone(&cmd_board), Arc::new(ce)));
+
+        let cmd = Arc::new(TestCommand::default().set_exe_should_fail());
+        {
+            cmd_board.write().needs_exe.insert(cmd.id().clone());
+        }
+
+        exe_tx.send_after_sync(Arc::clone(&cmd), 1);
+
+        sleep_millis(100).await;
+        assert!(er_rx.try_recv().is_err());
+        assert!(as_rx.try_recv().is_err());
+    }
 }

--- a/curp/src/server/cmd_execute_worker.rs
+++ b/curp/src/server/cmd_execute_worker.rs
@@ -8,7 +8,7 @@ use tokio::sync::oneshot;
 use tracing::{debug, error, warn};
 
 use crate::{
-    cmd::{Command, CommandExecutor},
+    cmd::{Command, CommandExecutor, ConflictCheck},
     conflict_checked_mpmc,
     conflict_checked_mpmc::{ConflictCheckedMsg, DoneNotifier},
     error::ExecuteError,
@@ -25,15 +25,15 @@ pub(super) async fn execute_worker<C: Command + 'static, CE: 'static + CommandEx
     cmd_board: CmdBoardRef<C>,
     ce: Arc<CE>,
 ) {
-    while let Ok((ExecuteMessage { cmd, er_tx }, done)) = dispatch_rx.recv().await {
-        match er_tx {
-            ExecuteMessageType::Execute(tx) => {
+    while let Ok((msg, done)) = dispatch_rx.recv().await {
+        match msg {
+            ExecuteMessage::Execute { cmd, er_tx } => {
                 let er = ce.execute(cmd.as_ref()).await;
                 debug!("cmd {:?} is executed", cmd.id());
                 cmd_board.write().insert_er(cmd.id(), er.clone()); // insert er
-                let _ignore = tx.send(er); // it's ok to ignore the result here because sometimes the result is not needed
+                let _ignore = er_tx.send(er); // it's ok to ignore the result here because sometimes the result is not needed
             }
-            ExecuteMessageType::AfterSync(index) => {
+            ExecuteMessage::AfterSync { cmd, index } => {
                 /// Different conditions in after sync
                 enum Condition {
                     /// Call both exe and after sync
@@ -78,6 +78,9 @@ pub(super) async fn execute_worker<C: Command + 'static, CE: 'static + CommandEx
                     Condition::Nothing => {}
                 }
             }
+            ExecuteMessage::Reset => {
+                ce.reset().await;
+            }
         }
         if let Err(e) = done.notify() {
             warn!("{e}");
@@ -87,34 +90,54 @@ pub(super) async fn execute_worker<C: Command + 'static, CE: 'static + CommandEx
 }
 
 /// Messages sent to the background cmd execution task
-struct ExecuteMessage<C: Command + 'static> {
-    /// The cmd to be executed
-    cmd: Arc<C>,
-    /// Send execution result
-    er_tx: ExecuteMessageType<C>,
+enum ExecuteMessage<C: Command + 'static> {
+    /// The cmd is ready for execution
+    Execute {
+        /// The cmd to be executed
+        cmd: Arc<C>,
+        /// Send execution result
+        er_tx: oneshot::Sender<Result<C::ER, ExecuteError>>,
+    },
+    /// The cmd is ready for after sync
+    AfterSync {
+        /// The cmd to be executed to be after aynced
+        cmd: Arc<C>,
+        /// Index of the cmd
+        index: LogIndex,
+    },
+    /// We need to reset the ce state
+    Reset,
+}
+
+/// Token of `ExecuteMessage`, used for conflict checking
+enum Token<C> {
+    /// Is a regular cmd exe or after sync
+    Cmd(Arc<C>),
+    /// Is a reset message
+    Reset,
+}
+
+impl<C: Command> ConflictCheck for Token<C> {
+    fn is_conflict(&self, other: &Self) -> bool {
+        match (self, other) {
+            (&Token::Cmd(ref cmd1), &Token::Cmd(ref cmd2)) => cmd1.is_conflict(cmd2),
+            // Reset should conflict with all others
+            _ => true,
+        }
+    }
 }
 
 impl<C: Command + 'static> ConflictCheckedMsg for ExecuteMessage<C> {
-    type Token = C;
+    type Token = Token<C>;
 
-    fn token(&self) -> Arc<Self::Token> {
-        Arc::clone(&self.cmd)
+    fn token(&self) -> Self::Token {
+        match *self {
+            ExecuteMessage::AfterSync { ref cmd, .. } | ExecuteMessage::Execute { ref cmd, .. } => {
+                Token::Cmd(Arc::clone(cmd))
+            }
+            ExecuteMessage::Reset => Token::Reset,
+        }
     }
-}
-
-impl<C: Command + 'static> ExecuteMessage<C> {
-    /// Create a new exe msg
-    fn new(cmd: Arc<C>, er_tx: ExecuteMessageType<C>) -> Self {
-        Self { cmd, er_tx }
-    }
-}
-
-/// Type of execute message
-enum ExecuteMessageType<C: Command + 'static> {
-    /// Only call `execute`
-    Execute(oneshot::Sender<Result<C::ER, ExecuteError>>),
-    /// After sync is ready to be called
-    AfterSync(LogIndex),
 }
 
 /// Send cmd to background execute cmd task
@@ -135,12 +158,15 @@ pub(super) trait CmdExeSenderInterface<C: Command> {
 
     /// Send after sync event to the background cmd executor so that after sync can be called
     fn send_after_sync(&self, cmd: Arc<C>, index: LogIndex);
+
+    /// Send flush
+    fn send_reset(&self);
 }
 
 impl<C: Command + 'static> CmdExeSenderInterface<C> for CmdExeSender<C> {
     fn send_exe(&self, cmd: Arc<C>) -> oneshot::Receiver<Result<C::ER, ExecuteError>> {
         let (tx, rx) = oneshot::channel();
-        let msg = ExecuteMessage::new(cmd, ExecuteMessageType::Execute(tx));
+        let msg = ExecuteMessage::Execute { cmd, er_tx: tx };
         if let Err(e) = self.0.send(msg) {
             warn!("failed to send cmd to background execute cmd task, {e}");
         }
@@ -148,7 +174,14 @@ impl<C: Command + 'static> CmdExeSenderInterface<C> for CmdExeSender<C> {
     }
 
     fn send_after_sync(&self, cmd: Arc<C>, index: LogIndex) {
-        let msg = ExecuteMessage::new(cmd, ExecuteMessageType::AfterSync(index));
+        let msg = ExecuteMessage::AfterSync { cmd, index };
+        if let Err(e) = self.0.send(msg) {
+            warn!("failed to send cmd to background execute cmd task, {e}");
+        }
+    }
+
+    fn send_reset(&self) {
+        let msg = ExecuteMessage::Reset;
         if let Err(e) = self.0.send(msg) {
             warn!("failed to send cmd to background execute cmd task, {e}");
         }

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -18,6 +18,7 @@ use tracing::{debug, error, info, instrument};
 
 use self::{
     cmd_board::{CmdState, CommandBoard},
+    cmd_execute_worker::CmdExeSenderInterface,
     gc::run_gc_tasks,
     spec_pool::SpeculativePool,
     state::State,
@@ -27,9 +28,9 @@ use crate::{
     error::{ProposeError, ServerError},
     message::{ServerId, TermNum},
     rpc::{
-        AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest, FetchLeaderResponse,
-        ProposeRequest, ProposeResponse, ProtocolServer, SyncError, VoteRequest, VoteResponse,
-        WaitSyncedRequest, WaitSyncedResponse,
+        connect::Connect, AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest,
+        FetchLeaderResponse, ProposeRequest, ProposeResponse, ProtocolServer, SyncError,
+        VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
     },
     server::cmd_execute_worker::{cmd_exe_channel, CmdExeSender},
     shutdown::Shutdown,
@@ -292,7 +293,7 @@ impl<C: 'static + Command> Protocol<C> {
         )));
 
         // run background tasks
-        let _bg_handle = tokio::spawn(bg_tasks::run_bg_tasks(
+        let _bg_handle = tokio::spawn(bg_tasks::run_bg_tasks::<_, _, Connect>(
             Arc::clone(&state),
             sync_rx,
             cmd_executor,
@@ -345,7 +346,7 @@ impl<C: 'static + Command> Protocol<C> {
         )));
 
         // run background tasks
-        let _bg_handle = tokio::spawn(bg_tasks::run_bg_tasks(
+        let _bg_handle = tokio::spawn(bg_tasks::run_bg_tasks::<_, _, Connect>(
             Arc::clone(&state),
             sync_rx,
             cmd_executor,

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -14,14 +14,11 @@ use lock_utils::parking_lot_lock::RwLockMap;
 use parking_lot::{lock_api::RwLockUpgradableReadGuard, Mutex, RwLock};
 use tokio::{net::TcpListener, sync::broadcast, time::Instant};
 use tokio_stream::wrappers::TcpListenerStream;
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
 use self::{
-    cmd_board::{CmdState, CommandBoard},
-    cmd_execute_worker::CmdExeSenderInterface,
-    gc::run_gc_tasks,
-    spec_pool::SpeculativePool,
-    state::State,
+    cmd_board::CommandBoard, cmd_execute_worker::CmdExeSenderInterface, gc::run_gc_tasks,
+    spec_pool::SpeculativePool, state::State,
 };
 use crate::{
     cmd::{Command, CommandExecutor},
@@ -32,7 +29,10 @@ use crate::{
         FetchLeaderResponse, ProposeRequest, ProposeResponse, ProtocolServer, SyncError,
         VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
     },
-    server::cmd_execute_worker::{cmd_exe_channel, CmdExeSender},
+    server::{
+        cmd_board::CmdBoardRef,
+        cmd_execute_worker::{cmd_exe_channel, CmdExeSender},
+    },
     shutdown::Shutdown,
     util::Extract,
 };
@@ -205,7 +205,7 @@ pub struct Protocol<C: Command + 'static> {
     sync_chan: flume::Sender<SyncMessage<C>>,
     // TODO: clean up the board when the size is too large
     /// Cmd watch board for tracking the cmd sync results
-    cmd_board: Arc<Mutex<CommandBoard>>,
+    cmd_board: CmdBoardRef<C>,
     /// Stop channel sender
     stop_ch_tx: broadcast::Sender<()>,
     /// The channel to send cmds to background exe tasks
@@ -274,7 +274,7 @@ impl<C: 'static + Command> Protocol<C> {
         cmd_executor: CE,
     ) -> Self {
         let (sync_tx, sync_rx) = flume::unbounded();
-        let cmd_board = Arc::new(Mutex::new(CommandBoard::new()));
+        let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
         let spec = Arc::new(Mutex::new(SpeculativePool::new()));
         let last_rpc_time = Arc::new(RwLock::new(Instant::now()));
         let (stop_ch_tx, stop_ch_rx) = broadcast::channel(1);
@@ -327,7 +327,7 @@ impl<C: 'static + Command> Protocol<C> {
         reachable: Arc<AtomicBool>,
     ) -> Self {
         let (sync_tx, sync_rx) = flume::unbounded();
-        let cmd_board = Arc::new(Mutex::new(CommandBoard::new()));
+        let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
         let spec = Arc::new(Mutex::new(SpeculativePool::new()));
         let last_rpc_time = Arc::new(RwLock::new(Instant::now()));
         let (stop_ch_tx, stop_ch_rx) = broadcast::channel(1);
@@ -372,16 +372,13 @@ impl<C: 'static + Command> Protocol<C> {
 
     /// Send sync event to the background sync task, it's not a blocking function
     #[instrument(skip(self))]
-    fn sync_to_others(&self, term: TermNum, cmd: Arc<C>, need_execute: bool) {
-        let mut cmd_board = self.cmd_board.lock();
-        let _ignore = cmd_board.cmd_states.insert(
-            cmd.id().clone(),
-            if need_execute {
-                CmdState::Execute
-            } else {
-                CmdState::AfterSync
-            },
-        );
+    fn sync_to_others(&self, term: TermNum, cmd: Arc<C>, needs_exe: bool) {
+        if needs_exe {
+            assert!(
+                self.cmd_board.write().needs_exe.insert(cmd.id().clone()),
+                "shouldn't insert needs_exe twice"
+            );
+        }
         if let Err(e) = self.sync_chan.send(SyncMessage::new(term, cmd)) {
             error!("send channel error, {e}");
         }
@@ -399,7 +396,7 @@ impl<C: 'static + Command> Protocol<C> {
             tonic::Status::invalid_argument(format!("propose cmd decode failed: {}", e))
         })?;
 
-        (|| async {
+        async {
             let (is_leader, leader_id, term) = self
                 .state
                 .map_read(|state| (state.is_leader(), state.leader_id.clone(), state.term));
@@ -408,17 +405,21 @@ impl<C: 'static + Command> Protocol<C> {
                 let mut spec = self.spec.lock();
 
                 // check if the command is ready
-                if spec.ready.contains_key(cmd.id()) {
+                if spec.ready.contains(cmd.id()) {
                     return ProposeResponse::new_empty(leader_id, term);
                 }
 
                 let has_conflict = spec.has_conflict_with(&cmd);
                 if !has_conflict {
-                    spec.push(cmd.as_ref().clone());
+                    spec.insert(Arc::clone(&cmd));
                 }
 
                 // non-leader should return immediately
                 if !is_leader {
+                    assert!(
+                        self.cmd_board.write().needs_exe.insert(cmd.id().clone()),
+                        "shouldn't insert needs_exe twice"
+                    );
                     return if has_conflict {
                         ProposeResponse::new_error(leader_id, term, &ProposeError::KeyConflict)
                     } else {
@@ -456,7 +457,7 @@ impl<C: 'static + Command> Protocol<C> {
                     &ProposeError::ProtocolError(err.to_string()),
                 ),
             }
-        })()
+        }
         .await
         .map_or_else(
             |err| {
@@ -482,6 +483,7 @@ impl<C: 'static + Command> Protocol<C> {
             tonic::Status::invalid_argument(format!("wait_synced id decode failed: {}", e))
         })?;
 
+        debug!("get wait synced request for {id:?}");
         let resp = loop {
             let listener = {
                 // check if the server is still leader
@@ -490,32 +492,33 @@ impl<C: 'static + Command> Protocol<C> {
                     break WaitSyncedResponse::new_error(&SyncError::Redirect(
                         state.leader_id.clone(),
                         state.term,
-                    ))
-                    .map_err(|err| {
-                        tonic::Status::internal(format!("encode or decode error, {}", err))
-                    });
+                    ));
                 }
 
                 // check if the cmd board already has response
-                let mut cmd_board = self.cmd_board.lock();
-                let entry = cmd_board
-                    .cmd_states
-                    .entry(id.clone())
-                    .or_insert(CmdState::EarlyArrive);
-                if let CmdState::FinalResponse(ref resp) = *entry {
-                    break resp.as_ref().map_or_else(
-                        |err| {
-                            Err(tonic::Status::internal(format!(
-                                "encode or decode error, {}",
-                                err
-                            )))
-                        },
-                        |r| Ok(r.clone()),
-                    );
+                let cmd_board_r = self.cmd_board.upgradable_read();
+                #[allow(clippy::pattern_type_mismatch)] // can't get away with this
+                match (
+                    cmd_board_r.er_buffer.get(&id),
+                    cmd_board_r.asr_buffer.get(&id),
+                ) {
+                    (Some(Err(err)), _) => {
+                        break WaitSyncedResponse::new_error(&SyncError::ExecuteError(
+                            err.to_string(),
+                        ));
+                    }
+                    (Some(er), Some(asr)) => {
+                        break WaitSyncedResponse::new_from_result::<C>(
+                            Some(er.clone()),
+                            Some(asr.clone()),
+                        );
+                    }
+                    _ => {}
                 }
 
+                let mut cmd_board_w = RwLockUpgradableReadGuard::upgrade(cmd_board_r);
                 // generate wait_synced event listener
-                cmd_board
+                cmd_board_w
                     .notifiers
                     .entry(id.clone())
                     .or_insert_with(Event::new)
@@ -525,14 +528,14 @@ impl<C: 'static + Command> Protocol<C> {
                 .await
                 .is_err()
             {
-                let _ignored = self.cmd_board.lock().notifiers.remove(&id);
-                break WaitSyncedResponse::new_error(&SyncError::Timeout).map_err(|err| {
-                    tonic::Status::internal(format!("encode or decode error, {}", err))
-                });
+                let _ignored = self.cmd_board.write().notifiers.remove(&id);
+                warn!("wait synced timeout for {id:?}");
+                break WaitSyncedResponse::new_error(&SyncError::Timeout);
             }
         };
-
+        debug!("wait synced for {id:?} finishes");
         resp.map(tonic::Response::new)
+            .map_err(|err| tonic::Status::internal(format!("encode or decode error, {}", err)))
     }
 
     /// Handle `AppendEntries` requests

--- a/curp/src/server/spec_pool.rs
+++ b/curp/src/server/spec_pool.rs
@@ -1,9 +1,13 @@
 use std::{collections::HashMap, sync::Arc};
 
 use indexmap::IndexSet;
+use parking_lot::Mutex;
 use tracing::debug;
 
 use crate::cmd::{Command, ProposeId};
+
+/// A reference to the speculative pool
+pub(super) type SpecPoolRef<C> = Arc<Mutex<SpeculativePool<C>>>;
 
 /// The speculative pool that stores commands that might be executed speculatively
 #[derive(Debug)]

--- a/curp/src/server/state.rs
+++ b/curp/src/server/state.rs
@@ -45,6 +45,8 @@ pub(super) struct State<C: Command + 'static> {
     pub(super) commit_trigger: Arc<Event>,
     /// Trigger when a new leader needs to calibrate its followers
     pub(super) calibrate_trigger: Arc<Event>,
+    /// Trigger when append_entires are sent and no heartbeat is needed for a while
+    pub(super) heartbeat_reset_trigger: Arc<Event>,
     // TODO: clean up the board when the size is too large
     /// Cmd watch board for tracking the cmd sync results
     pub(super) cmd_board: Arc<Mutex<CommandBoard>>,
@@ -83,6 +85,7 @@ impl<C: Command + 'static> State<C> {
             role_trigger: Arc::new(Event::new()),
             commit_trigger: Arc::new(Event::new()),
             calibrate_trigger: Arc::new(Event::new()),
+            heartbeat_reset_trigger: Arc::new(Event::new()),
             cmd_board,
             last_rpc_time,
         }
@@ -163,5 +166,10 @@ impl<C: Command + 'static> State<C> {
     /// Get `cmd_board`
     pub(super) fn cmd_board(&self) -> Arc<Mutex<CommandBoard>> {
         Arc::clone(&self.cmd_board)
+    }
+
+    /// Get heartbeat reset trigger
+    pub(super) fn heartbeat_reset_trigger(&self) -> Arc<Event> {
+        Arc::clone(&self.heartbeat_reset_trigger)
     }
 }

--- a/curp/src/server/tests.rs
+++ b/curp/src/server/tests.rs
@@ -33,7 +33,7 @@ use tracing_test::traced_test;
 
 use crate::{
     message::{ServerId, TermNum},
-    rpc::ProposeRequest,
+    rpc::{connect::ConnectInterface, ProposeRequest},
     server::{state::State, Rpc},
     test_utils::{
         curp_group::{CurpGroup, CurpNode},
@@ -321,7 +321,7 @@ async fn propose_after_reelect() {
     let client = group.new_client().await;
     assert_eq!(
         client
-            .propose(TestCommand::new_put(0, vec![0], 0))
+            .propose(TestCommand::new_put(vec![0], 0))
             .await
             .unwrap(),
         vec![]
@@ -334,10 +334,7 @@ async fn propose_after_reelect() {
 
     tokio::time::sleep(Duration::from_secs(2)).await;
     assert_eq!(
-        client
-            .propose(TestCommand::new_get(1, vec![0]))
-            .await
-            .unwrap(),
+        client.propose(TestCommand::new_get(vec![0])).await.unwrap(),
         vec![0]
     );
 }
@@ -348,7 +345,7 @@ async fn propose_after_reelect() {
 async fn fast_round_is_slower_than_slow_round() {
     let group = CurpGroup::new(3).await;
     let client = group.new_client().await;
-    let cmd = Arc::new(TestCommand::new_get(0, vec![0]));
+    let cmd = Arc::new(TestCommand::new_get(vec![0]));
 
     let leader = group.get_leader().await;
 

--- a/curp/src/test_utils/mod.rs
+++ b/curp/src/test_utils/mod.rs
@@ -13,5 +13,15 @@
     unused_results
 )]
 
+use std::time::Duration;
+
 pub(crate) mod curp_group;
 pub(crate) mod test_cmd;
+
+pub(crate) async fn sleep_millis(n: u64) {
+    tokio::time::sleep(Duration::from_millis(n)).await;
+}
+
+pub(crate) async fn sleep_secs(n: u64) {
+    tokio::time::sleep(Duration::from_secs(n)).await;
+}

--- a/curp/src/test_utils/test_cmd.rs
+++ b/curp/src/test_utils/test_cmd.rs
@@ -175,6 +175,10 @@ impl CommandExecutor<TestCommand> for TestCE {
             .expect("failed to send after sync msg");
         Ok(index)
     }
+
+    async fn reset(&self) {
+        self.store.lock().clear();
+    }
 }
 
 impl TestCE {
@@ -236,6 +240,10 @@ impl CommandExecutor<TestCommand> for TestCESimple {
 
         debug!("{} call cmd {:?} after sync", self.server_id, cmd.id());
         Ok(index)
+    }
+
+    async fn reset(&self) {
+        self.store.lock().clear();
     }
 }
 

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -76,7 +76,7 @@ impl CurpGroup {
             })
             .collect();
 
-        tokio::time::sleep(Duration::from_secs(2)).await;
+        tokio::time::sleep(Duration::from_secs(3)).await;
         Self { nodes }
     }
 

--- a/curp/tests/common/test_cmd.rs
+++ b/curp/tests/common/test_cmd.rs
@@ -154,6 +154,10 @@ impl CommandExecutor<TestCommand> for TestCE {
             .expect("failed to send after sync msg");
         Ok(index)
     }
+
+    async fn reset(&self) {
+        self.store.lock().clear();
+    }
 }
 
 impl TestCE {

--- a/xline/src/rpc/mod.rs
+++ b/xline/src/rpc/mod.rs
@@ -71,40 +71,42 @@ mod leasepb {
 
 use serde::{Deserialize, Serialize};
 
-pub(crate) use self::authpb::{permission::Type, Permission, Role, User};
-pub(crate) use self::etcdserverpb::{
-    auth_server::{Auth, AuthServer},
-    compare::{CompareResult, CompareTarget, TargetUnion},
-    kv_server::{Kv, KvServer},
-    lease_server::{Lease, LeaseServer},
-    request_op::Request,
-    response_op::Response,
-    watch_request::RequestUnion,
-    watch_server::{Watch, WatchServer},
-    AuthDisableRequest, AuthDisableResponse, AuthEnableRequest, AuthEnableResponse,
-    AuthRoleAddRequest, AuthRoleAddResponse, AuthRoleDeleteRequest, AuthRoleDeleteResponse,
-    AuthRoleGetRequest, AuthRoleGetResponse, AuthRoleGrantPermissionRequest,
-    AuthRoleGrantPermissionResponse, AuthRoleListRequest, AuthRoleListResponse,
-    AuthRoleRevokePermissionRequest, AuthRoleRevokePermissionResponse, AuthStatusRequest,
-    AuthStatusResponse, AuthUserAddRequest, AuthUserAddResponse, AuthUserChangePasswordRequest,
-    AuthUserChangePasswordResponse, AuthUserDeleteRequest, AuthUserDeleteResponse,
-    AuthUserGetRequest, AuthUserGetResponse, AuthUserGrantRoleRequest, AuthUserGrantRoleResponse,
-    AuthUserListRequest, AuthUserListResponse, AuthUserRevokeRoleRequest,
-    AuthUserRevokeRoleResponse, AuthenticateRequest, AuthenticateResponse, CompactionRequest,
-    CompactionResponse, Compare, DeleteRangeRequest, DeleteRangeResponse, LeaseGrantRequest,
-    LeaseGrantResponse, LeaseKeepAliveRequest, LeaseKeepAliveResponse, LeaseLeasesRequest,
-    LeaseLeasesResponse, LeaseRevokeRequest, LeaseRevokeResponse, LeaseTimeToLiveRequest,
-    LeaseTimeToLiveResponse, PutRequest, PutResponse, RangeRequest, RangeResponse, RequestOp,
-    ResponseHeader, ResponseOp, TxnRequest, TxnResponse, WatchCancelRequest, WatchCreateRequest,
-    WatchRequest, WatchResponse,
-};
-pub(crate) use self::mvccpb::{event::EventType, Event, KeyValue};
-pub(crate) use self::v3lockpb::{
-    lock_server::{Lock, LockServer},
-    LockRequest, LockResponse, UnlockRequest, UnlockResponse,
-};
-
 pub use self::etcdserverpb::range_request::{SortOrder, SortTarget};
+pub(crate) use self::{
+    authpb::{permission::Type, Permission, Role, User},
+    etcdserverpb::{
+        auth_server::{Auth, AuthServer},
+        compare::{CompareResult, CompareTarget, TargetUnion},
+        kv_server::{Kv, KvServer},
+        lease_server::{Lease, LeaseServer},
+        request_op::Request,
+        response_op::Response,
+        watch_request::RequestUnion,
+        watch_server::{Watch, WatchServer},
+        AuthDisableRequest, AuthDisableResponse, AuthEnableRequest, AuthEnableResponse,
+        AuthRoleAddRequest, AuthRoleAddResponse, AuthRoleDeleteRequest, AuthRoleDeleteResponse,
+        AuthRoleGetRequest, AuthRoleGetResponse, AuthRoleGrantPermissionRequest,
+        AuthRoleGrantPermissionResponse, AuthRoleListRequest, AuthRoleListResponse,
+        AuthRoleRevokePermissionRequest, AuthRoleRevokePermissionResponse, AuthStatusRequest,
+        AuthStatusResponse, AuthUserAddRequest, AuthUserAddResponse, AuthUserChangePasswordRequest,
+        AuthUserChangePasswordResponse, AuthUserDeleteRequest, AuthUserDeleteResponse,
+        AuthUserGetRequest, AuthUserGetResponse, AuthUserGrantRoleRequest,
+        AuthUserGrantRoleResponse, AuthUserListRequest, AuthUserListResponse,
+        AuthUserRevokeRoleRequest, AuthUserRevokeRoleResponse, AuthenticateRequest,
+        AuthenticateResponse, CompactionRequest, CompactionResponse, Compare, DeleteRangeRequest,
+        DeleteRangeResponse, LeaseGrantRequest, LeaseGrantResponse, LeaseKeepAliveRequest,
+        LeaseKeepAliveResponse, LeaseLeasesRequest, LeaseLeasesResponse, LeaseRevokeRequest,
+        LeaseRevokeResponse, LeaseTimeToLiveRequest, LeaseTimeToLiveResponse, PutRequest,
+        PutResponse, RangeRequest, RangeResponse, RequestOp, ResponseHeader, ResponseOp,
+        TxnRequest, TxnResponse, WatchCancelRequest, WatchCreateRequest, WatchRequest,
+        WatchResponse,
+    },
+    mvccpb::{event::EventType, Event, KeyValue},
+    v3lockpb::{
+        lock_server::{Lock, LockServer},
+        LockRequest, LockResponse, UnlockRequest, UnlockResponse,
+    },
+};
 
 impl User {
     /// Check if user has the given role

--- a/xline/src/server/auth_server.rs
+++ b/xline/src/server/auth_server.rs
@@ -9,6 +9,7 @@ use tonic::metadata::MetadataMap;
 use tracing::debug;
 use uuid::Uuid;
 
+use super::command::{Command, CommandResponse, SyncResponse};
 use crate::{
     rpc::{
         Auth, AuthDisableRequest, AuthDisableResponse, AuthEnableRequest, AuthEnableResponse,
@@ -25,8 +26,6 @@ use crate::{
     },
     storage::AuthStore,
 };
-
-use super::command::{Command, CommandResponse, SyncResponse};
 
 /// Auth Server
 #[derive(Debug)]

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -205,6 +205,9 @@ impl CurpCommandExecutor<Command> for CommandExecutor {
             RequestBackend::Auth => Ok(self.auth_storage.after_sync(&id)),
         }
     }
+
+    // TODO
+    async fn reset(&self) {}
 }
 
 /// Command to run consensus protocal

--- a/xline/src/storage/authstore/backend.rs
+++ b/xline/src/storage/authstore/backend.rs
@@ -22,12 +22,9 @@ use pbkdf2::{
 };
 use prost::Message;
 
+use super::perms::{JwtTokenManager, PermissionCache, TokenClaims, TokenOperate, UserPermissions};
 use crate::{
     header_gen::HeaderGenerator,
-    server::command::KeyRange,
-    storage::{db::DB, index::Index, req_ctx::RequestCtx},
-};
-use crate::{
     rpc::{
         AuthDisableRequest, AuthDisableResponse, AuthEnableRequest, AuthEnableResponse,
         AuthRoleAddRequest, AuthRoleAddResponse, AuthRoleDeleteRequest, AuthRoleDeleteResponse,
@@ -42,10 +39,13 @@ use crate::{
         AuthenticateResponse, KeyValue, Permission, RequestWrapper, ResponseWrapper, Role, Type,
         User,
     },
-    storage::index::IndexOperate,
+    server::command::KeyRange,
+    storage::{
+        db::DB,
+        index::{Index, IndexOperate},
+        req_ctx::RequestCtx,
+    },
 };
-
-use super::perms::{JwtTokenManager, PermissionCache, TokenClaims, TokenOperate, UserPermissions};
 
 /// Key prefix of user
 pub(crate) const USER_PREFIX: &[u8] = b"user/";

--- a/xline/src/storage/kvstore.rs
+++ b/xline/src/storage/kvstore.rs
@@ -6,16 +6,22 @@ use parking_lot::Mutex;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use super::index::IndexOperate;
-use super::{db::DB, index::Index, kvwatcher::KvWatcher};
-use crate::header_gen::HeaderGenerator;
-use crate::rpc::{
-    Compare, CompareResult, CompareTarget, DeleteRangeRequest, DeleteRangeResponse, Event,
-    EventType, KeyValue, PutRequest, PutResponse, RangeRequest, RangeResponse, RequestWithToken,
-    RequestWrapper, ResponseWrapper, SortOrder, SortTarget, TargetUnion, TxnRequest, TxnResponse,
+use super::{
+    db::DB,
+    index::{Index, IndexOperate},
+    kvwatcher::KvWatcher,
 };
-use crate::server::command::{CommandResponse, KeyRange, SyncResponse};
-use crate::storage::req_ctx::RequestCtx;
+use crate::{
+    header_gen::HeaderGenerator,
+    rpc::{
+        Compare, CompareResult, CompareTarget, DeleteRangeRequest, DeleteRangeResponse, Event,
+        EventType, KeyValue, PutRequest, PutResponse, RangeRequest, RangeResponse,
+        RequestWithToken, RequestWrapper, ResponseWrapper, SortOrder, SortTarget, TargetUnion,
+        TxnRequest, TxnResponse,
+    },
+    server::command::{CommandResponse, KeyRange, SyncResponse},
+    storage::req_ctx::RequestCtx,
+};
 
 /// Default channel size
 const CHANNEL_SIZE: usize = 128;

--- a/xline/src/storage/mod.rs
+++ b/xline/src/storage/mod.rs
@@ -19,5 +19,4 @@ pub(crate) mod kvwatcher;
 /// Request context module
 pub(crate) mod req_ctx;
 
-pub(crate) use self::authstore::AuthStore;
-pub(crate) use self::kvstore::KvStore;
+pub(crate) use self::{authstore::AuthStore, kvstore::KvStore};


### PR DESCRIPTION
Based on #127

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
On leader changes, old leader should reset ce and new leader should recover speculatively executed cmds.

* what changes does this pull request make?
On leader changes, old leader resets ce and new leader recovers speculatively executed cmds.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No