### PR TITLE
refactor and improve xline server

### DIFF
--- a/xline/Cargo.toml
+++ b/xline/Cargo.toml
@@ -53,6 +53,7 @@ getset = "0.1"
 toml = "0.5"
 tracing-appender = "0.2"
 priority-queue = "1.3.0"
+futures = "0.3.25"
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/xline/src/header_gen.rs
+++ b/xline/src/header_gen.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 
-use crate::rpc::ResponseHeader;
+use crate::{revision_number::RevisionNumber, rpc::ResponseHeader};
 
 /// Generator of `ResponseHeader`
 #[derive(Debug)]
@@ -14,7 +14,7 @@ pub(crate) struct HeaderGenerator {
     /// term of curp
     term: Arc<Mutex<u64>>,
     /// revision of kv store
-    revision: Arc<Mutex<i64>>,
+    revision: Arc<RevisionNumber>,
 }
 
 impl HeaderGenerator {
@@ -24,7 +24,7 @@ impl HeaderGenerator {
             cluster_id,
             member_id,
             term: Arc::new(Mutex::new(0)),
-            revision: Arc::new(Mutex::new(1)),
+            revision: Arc::new(RevisionNumber::new()),
         }
     }
 
@@ -34,7 +34,7 @@ impl HeaderGenerator {
             cluster_id: self.cluster_id,
             member_id: self.member_id,
             raft_term: *self.term.lock(),
-            revision: *self.revision.lock(),
+            revision: self.revision(),
         }
     }
 
@@ -56,11 +56,11 @@ impl HeaderGenerator {
 
     /// Get revision
     pub(crate) fn revision(&self) -> i64 {
-        *self.revision.lock()
+        self.revision.get()
     }
 
     /// Return Arc of revision
-    pub(crate) fn revision_arc(&self) -> Arc<Mutex<i64>> {
+    pub(crate) fn revision_arc(&self) -> Arc<RevisionNumber> {
         Arc::clone(&self.revision)
     }
 }

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -38,7 +38,7 @@
     unused_results,
     variant_size_differences,
 
-    warnings, // treat all wanings as errors
+    warnings, // treat all warnings as errors
 
     clippy::all,
     clippy::pedantic,
@@ -117,6 +117,8 @@ pub mod client;
 mod header_gen;
 /// Unique id generator
 mod id_gen;
+/// Revision number
+mod revision_number;
 /// rpc definition module
 mod rpc;
 /// Xline server

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -38,7 +38,7 @@
     unused_results,
     variant_size_differences,
 
-    warnings, // treat all wanings as errors
+    warnings, // treat all warnings as errors
 
     clippy::all,
     clippy::pedantic,
@@ -112,7 +112,7 @@
 
 use std::{collections::HashMap, env, path::PathBuf, time::Duration};
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::Parser;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use opentelemetry::{global, runtime::Tokio, sdk::propagation::TraceContextPropagator};
@@ -143,16 +143,16 @@ struct ServerArgs {
     /// If node is leader
     #[clap(long)]
     is_leader: bool,
-    /// Private key uesd to sign the token
+    /// Private key used to sign the token
     #[clap(long)]
     auth_private_key: Option<PathBuf>,
-    /// Public key uesd to verify the token
+    /// Public key used to verify the token
     #[clap(long)]
     auth_public_key: Option<PathBuf>,
     /// Open jaeger offline
     #[clap(long)]
     jaeger_offline: bool,
-    /// ouput dir for jaeger offline
+    /// output dir for jaeger offline
     #[clap(long, default_value = "./jaeger_jsons")]
     jaeger_output_dir: PathBuf,
     /// Open jaeger online
@@ -351,12 +351,12 @@ async fn main() -> Result<()> {
     let self_addr = cluster_config
         .members()
         .get(cluster_config.name())
-        .unwrap_or_else(|| {
-            panic!(
+        .ok_or_else(|| {
+            anyhow!(
                 "node name {} not found in cluster peers",
                 cluster_config.name()
             )
-        })
+        })?
         .parse()?;
 
     let is_leader = cluster_config.is_leader();

--- a/xline/src/revision_number.rs
+++ b/xline/src/revision_number.rs
@@ -1,0 +1,20 @@
+use std::sync::atomic::{AtomicI64, Ordering};
+
+/// Revision number
+#[derive(Debug)]
+pub(crate) struct RevisionNumber(AtomicI64);
+
+impl RevisionNumber {
+    /// Create a new revision
+    pub(crate) fn new() -> Self {
+        Self(AtomicI64::new(1))
+    }
+    /// Get the revision number
+    pub(crate) fn get(&self) -> i64 {
+        self.0.load(Ordering::Relaxed)
+    }
+    /// Get the next revision number
+    pub(crate) fn next(&self) -> i64 {
+        self.0.fetch_add(1, Ordering::SeqCst).wrapping_add(1)
+    }
+}

--- a/xline/src/server/watch_server.rs
+++ b/xline/src/server/watch_server.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashSet, sync::Arc};
 
 use clippy_utilities::OverflowArithmetic;
 use tokio::sync::mpsc;
@@ -11,7 +11,7 @@ use crate::{
         RequestUnion, ResponseHeader, Watch, WatchCancelRequest, WatchCreateRequest, WatchRequest,
         WatchResponse,
     },
-    storage::kvwatcher::{KvWatcher, KvWatcherOps, WatchEvent, WatchId, Watcher},
+    storage::kvwatcher::{KvWatcher, KvWatcherOps, WatchEvent, WatchId},
 };
 
 /// Default channel size
@@ -32,7 +32,7 @@ impl WatchServer {
 
     /// bg task for handle watch connection
     #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
-    pub(crate) async fn task<S, W>(
+    async fn task<S, W>(
         kv_watcher: Arc<W>,
         res_tx: mpsc::Sender<Result<WatchResponse, tonic::Status>>,
         mut req_rx: S,
@@ -91,7 +91,7 @@ where
     /// Event sender
     event_tx: mpsc::Sender<WatchEvent>,
     /// Watch ID to watcher map
-    watcher_map: HashMap<WatchId, Watcher>,
+    active_watch_ids: HashSet<WatchId>,
     /// Next available `WatchId`
     next_id: WatchId,
     /// Stop tx
@@ -115,82 +115,34 @@ where
             response_tx,
             event_rx,
             event_tx,
-            watcher_map: HashMap::new(),
-            next_id: 0,
+            active_watch_ids: HashSet::new(),
+            next_id: 1, // watch_id starts from 1, 0 means auto-generating
             stop_tx,
         }
     }
 
-    /// Get next available `WatchId`, return None if id is not available
-    fn get_next_watch_id(&mut self, id: WatchId) -> Option<WatchId> {
+    /// Validate the given `watch_id`, return None if the given id is not available, will generate a new one if the given one equals 0
+    fn validate_watch_id(&mut self, watch_id: WatchId) -> Option<WatchId> {
         // 0 means auto-generate
-        if id == 0 {
+        if watch_id == 0 {
             loop {
                 let next = self.next_id;
                 self.next_id = self.next_id.overflow_add(1);
-                if self.watcher_map.get(&next).is_none() {
+                if !self.active_watch_ids.contains(&next) {
                     break Some(next);
                 }
             }
-        } else if self.watcher_map.get(&id).is_some() {
+        } else if self.active_watch_ids.contains(&watch_id) {
             None
         } else {
-            Some(id)
+            Some(watch_id)
         }
     }
 
     /// Handle `WatchCreateRequest`
     async fn handle_watch_create(&mut self, req: WatchCreateRequest) {
-        let watch_id = self.get_next_watch_id(req.watch_id);
-        if let Some(watch_id) = watch_id {
-            let key_range = KeyRange {
-                start: req.key,
-                end: req.range_end,
-            };
-
-            let (watcher, events, revision) = self.kv_watcher.watch(
-                watch_id,
-                key_range,
-                req.start_revision,
-                req.filters,
-                self.event_tx.clone(),
-            );
-            assert!(
-                self.watcher_map.insert(watch_id, watcher).is_none(),
-                "WatchId {} already exists in watcher_map",
-                watch_id
-            );
-
-            let response = WatchResponse {
-                header: Some(ResponseHeader {
-                    revision,
-                    ..ResponseHeader::default()
-                }),
-                watch_id,
-                created: true,
-                ..WatchResponse::default()
-            };
-            if self.response_tx.send(Ok(response)).await.is_err() {
-                self.stop_tx.send(()).unwrap_or_else(|e| {
-                    warn!("failed to send stop signal: {}", e);
-                });
-            }
-            if !events.is_empty() {
-                let event_response = WatchResponse {
-                    header: Some(ResponseHeader {
-                        revision,
-                        ..ResponseHeader::default()
-                    }),
-                    watch_id,
-                    events,
-                    ..WatchResponse::default()
-                };
-                if self.response_tx.send(Ok(event_response)).await.is_err() {
-                    self.stop_tx.send(()).unwrap_or_else(|e| {
-                        warn!("failed to send stop signal: {}", e);
-                    });
-                }
-            }
+        let watch_id = if let Some(id) = self.validate_watch_id(req.watch_id) {
+            id
         } else {
             let result = Err(tonic::Status::already_exists(format!(
                 "Watch ID {} has already been used",
@@ -201,31 +153,80 @@ where
                     warn!("failed to send stop signal: {}", e);
                 });
             }
+            return;
+        };
+
+        let key_range = KeyRange {
+            start: req.key,
+            end: req.range_end,
+        };
+        let (events, revision) = self.kv_watcher.watch(
+            watch_id,
+            key_range,
+            req.start_revision,
+            req.filters,
+            self.event_tx.clone(),
+        );
+        assert!(
+            self.active_watch_ids.insert(watch_id),
+            "WatchId {} already exists in watcher_map",
+            watch_id
+        );
+
+        let response = WatchResponse {
+            header: Some(ResponseHeader {
+                revision,
+                ..ResponseHeader::default()
+            }),
+            watch_id,
+            created: true,
+            ..WatchResponse::default()
+        };
+        if self.response_tx.send(Ok(response)).await.is_err() {
+            self.stop_tx.send(()).unwrap_or_else(|e| {
+                warn!("failed to send stop signal: {}", e);
+            });
+        }
+        // send initial events
+        if !events.is_empty() {
+            let event_response = WatchResponse {
+                header: Some(ResponseHeader {
+                    revision,
+                    ..ResponseHeader::default()
+                }),
+                watch_id,
+                events,
+                ..WatchResponse::default()
+            };
+            if self.response_tx.send(Ok(event_response)).await.is_err() {
+                self.stop_tx.send(()).unwrap_or_else(|e| {
+                    warn!("failed to send stop signal: {}", e);
+                });
+            }
         }
     }
 
     /// Handle `WatchCancelRequest`
     async fn handle_watch_cancel(&mut self, req: WatchCancelRequest) {
         let watch_id = req.watch_id;
-        let result = match self.watcher_map.get(&watch_id) {
-            Some(watcher) => {
-                let revision = self.kv_watcher.cancel(watcher);
-                let _prev = self.watcher_map.remove(&watch_id);
-                let response = WatchResponse {
-                    header: Some(ResponseHeader {
-                        revision,
-                        ..ResponseHeader::default()
-                    }),
-                    watch_id,
-                    canceled: true,
-                    ..WatchResponse::default()
-                };
-                Ok(response)
-            }
-            None => Err(tonic::Status::not_found(format!(
+        let result = if self.active_watch_ids.remove(&watch_id) {
+            let revision = self.kv_watcher.cancel(watch_id);
+            let _prev = self.active_watch_ids.remove(&watch_id);
+            let response = WatchResponse {
+                header: Some(ResponseHeader {
+                    revision,
+                    ..ResponseHeader::default()
+                }),
+                watch_id,
+                canceled: true,
+                ..WatchResponse::default()
+            };
+            Ok(response)
+        } else {
+            Err(tonic::Status::not_found(format!(
                 "Watch ID {} doesn't exist",
                 req.watch_id
-            ))),
+            )))
         };
         if self.response_tx.send(result).await.is_err() {
             self.stop_tx.send(()).unwrap_or_else(|e| {
@@ -255,6 +256,9 @@ where
     async fn handle_watch_event(&mut self, mut event: WatchEvent) {
         let watch_id = event.watch_id();
         let events = event.take_events();
+        if events.is_empty() {
+            return;
+        }
         let response = WatchResponse {
             header: Some(ResponseHeader {
                 revision: event.revision(),
@@ -277,8 +281,8 @@ where
     W: KvWatcherOps,
 {
     fn drop(&mut self) {
-        for watcher in self.watcher_map.values() {
-            let _revision = self.kv_watcher.cancel(watcher);
+        for watch_id in &self.active_watch_ids {
+            let _revision = self.kv_watcher.cancel(*watch_id);
         }
     }
 }
@@ -307,9 +311,6 @@ impl Watch for WatchServer {
 
 #[cfg(test)]
 mod test {
-
-    use parking_lot::Mutex;
-
     use super::*;
     use crate::storage::kvwatcher::MockKvWatcherOps;
 
@@ -322,23 +323,11 @@ mod test {
             ReceiverStream::new(req_rx);
 
         let mut mock_watcher = MockKvWatcherOps::new();
-        let option1 = Arc::new(Mutex::new(None));
-        let option2 = Arc::clone(&option1);
-        let _ = mock_watcher.expect_watch().times(1).returning(
-            move |id, key_range, start_rev, filters, event_tx| {
-                let watcher = Watcher::new(key_range, id, start_rev, filters, event_tx);
-                *option1.lock() = Some(watcher.clone());
-                (watcher, vec![], 0)
-            },
-        );
         let _ = mock_watcher
-            .expect_cancel()
+            .expect_watch()
             .times(1)
-            .returning(move |watcher| {
-                // make sure cancel is called with the same watcher
-                assert_eq!(Some(watcher), option2.lock().as_ref());
-                0
-            });
+            .return_const((vec![], 0));
+        let _ = mock_watcher.expect_cancel().times(1).returning(move |_| 0);
         let watcher = Arc::new(mock_watcher);
 
         let handle = tokio::spawn(WatchServer::task(Arc::clone(&watcher), res_tx, req_stream));

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -147,7 +147,7 @@ impl XlineServer {
     ///
     /// Will return `Err` when `tonic::Server` serve return an error
     #[inline]
-    pub async fn start_from_listener_shoutdown<F>(
+    pub async fn start_from_listener_shutdown<F>(
         &self,
         xline_listener: TcpListener,
         signal: F,

--- a/xline/src/storage/auth_store/backend.rs
+++ b/xline/src/storage/auth_store/backend.rs
@@ -199,11 +199,11 @@ impl AuthStoreBackend {
     fn create_permission_cache(&self) {
         let mut permission_cache = PermissionCache::new();
         for user in self.get_all_users() {
-            let user_permisiion = self.get_user_permissions(&user);
+            let user_permission = self.get_user_permissions(&user);
             let username = String::from_utf8_lossy(&user.name).to_string();
             let _ignore = permission_cache
                 .user_permissions
-                .insert(username, user_permisiion);
+                .insert(username, user_permission);
         }
         self.permission_cache
             .map_write(|mut cache| *cache = permission_cache);
@@ -211,7 +211,7 @@ impl AuthStoreBackend {
 
     /// get user permissions
     fn get_user_permissions(&self, user: &User) -> UserPermissions {
-        let mut user_permisiion = UserPermissions::new();
+        let mut user_permission = UserPermissions::new();
         for role_name in &user.roles {
             let role = match self.get_role(role_name) {
                 Ok(role) => role,
@@ -225,19 +225,19 @@ impl AuthStoreBackend {
                 #[allow(clippy::unwrap_used)] // safe unwrap
                 match Type::from_i32(permission.perm_type).unwrap() {
                     Type::Readwrite => {
-                        user_permisiion.read.push(key_range.clone());
-                        user_permisiion.write.push(key_range.clone());
+                        user_permission.read.push(key_range.clone());
+                        user_permission.write.push(key_range.clone());
                     }
                     Type::Write => {
-                        user_permisiion.write.push(key_range.clone());
+                        user_permission.write.push(key_range.clone());
                     }
                     Type::Read => {
-                        user_permisiion.read.push(key_range.clone());
+                        user_permission.read.push(key_range.clone());
                     }
                 }
             }
         }
-        user_permisiion
+        user_permission
     }
 
     /// get user permissions from cache

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -60,7 +60,6 @@ pub(crate) struct KvStoreBackend {
 
 impl KvStore {
     /// New `KvStore`
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
     pub(crate) fn new(
         lease_cmd_tx: mpsc::Sender<LeaseMessage>,
         del_rx: mpsc::Receiver<DeleteMessage>,
@@ -158,7 +157,7 @@ impl KvStoreBackend {
     async fn notify_updates(&self, revision: i64, updates: Vec<Event>) {
         assert!(
             self.kv_update_tx.send((revision, updates)).await.is_ok(),
-            "Failed to send updates to KV watchter"
+            "Failed to send updates to KV watcher"
         );
     }
 
@@ -293,7 +292,7 @@ impl KvStoreBackend {
         };
     }
 
-    /// fitler kvs by `{max,min}_{mod,create}_revision`
+    /// filter kvs by `{max,min}_{mod,create}_revision`
     fn filter_kvs(
         kvs: &mut Vec<KeyValue>,
         max_mod_revision: i64,

--- a/xline/src/storage/revision.rs
+++ b/xline/src/storage/revision.rs
@@ -1,4 +1,4 @@
-/// Revison of a key
+/// Revision of a key
 #[derive(Debug, Copy, Clone)]
 pub(crate) struct KeyRevision {
     /// Last creation revision

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -67,7 +67,7 @@ impl Cluster {
                 let signal = async {
                     let _ = rx.recv().await;
                 };
-                let result = server.start_from_listener_shoutdown(listener, signal).await;
+                let result = server.start_from_listener_shutdown(listener, signal).await;
                 if let Err(e) = result {
                     panic!("Server start error: {e}");
                 }


### PR DESCRIPTION
1. Watcher should be an inner struct in the storage module. It should not appear in the server module. WatchServer only needs to maintain watch_id, no need to maintain watcher.
2. Some renaming
3. Use a RwLock to store watchers so that different watchers can send concurrently
4. Unnecessary Arc<Inner>: Watcher has an inner of type Arc<WatcherInner>. When Watcher needs to be shared, we previously Clone on Watcher. Just use Arc<Watcher> is both clearer and simpler.
5. Improve filter events performance: previously events are filtered by key_range twice, now only once
6. Watch id should be assigned from 1 instead of 0 because 0 means auto-generated, which might be confusing to the client
7. Reduce code duplication
8. Use atomici64 for the revision number.
9. Fix in auth backend concurrent bugs due to the revision number

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Refactor and improve KV watch

* what changes does this pull request make?
Refactors

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No.