### PR TITLE
abstract DB as a trait

### DIFF
--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -38,7 +38,7 @@
     unused_results,
     variant_size_differences,
 
-    warnings, // treat all wanings as errors
+    warnings, // treat all warns as errors
 
     clippy::all,
     clippy::pedantic,

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -127,3 +127,5 @@ pub mod server;
 mod state;
 /// Storage module
 mod storage;
+
+pub use storage::memory::Memory;

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -128,7 +128,7 @@ use utils::{
     },
     parse_duration, parse_log_level, parse_members, parse_range, parse_rotation,
 };
-use xline::server::XlineServer;
+use xline::{server::XlineServer, Memory};
 
 /// Command line arguments
 #[derive(Parser)]
@@ -363,6 +363,7 @@ async fn main() -> Result<()> {
     debug!("name = {:?}", cluster_config.name());
     debug!("server_addr = {:?}", self_addr);
     debug!("cluster_peers = {:?}", cluster_config.members());
+    let mem_storage = Memory::new();
     let server = XlineServer::new(
         cluster_config.name().clone(),
         cluster_config.members().clone(),
@@ -370,6 +371,7 @@ async fn main() -> Result<()> {
         key_pair,
         cluster_config.server_timeout().clone(),
         *cluster_config.client_timeout(),
+        mem_storage,
     )
     .await;
     debug!("{:?}", server);

--- a/xline/src/rpc/mod.rs
+++ b/xline/src/rpc/mod.rs
@@ -80,7 +80,7 @@ pub(crate) use self::{
         kv_client::KvClient,
         kv_server::{Kv, KvServer},
         lease_client::LeaseClient,
-        lease_server::{Lease as LeaseTrait, LeaseServer},
+        lease_server::{Lease, LeaseServer},
         request_op::Request,
         response_op::Response,
         watch_client::WatchClient,

--- a/xline/src/storage/memory.rs
+++ b/xline/src/storage/memory.rs
@@ -1,0 +1,70 @@
+use std::{collections::HashMap, convert::Infallible};
+
+use super::storage_api::StorageApi;
+
+/// default storage implementation
+#[derive(Debug, Default, Clone)]
+pub struct Memory(HashMap<Vec<u8>, Vec<u8>>);
+
+impl Memory {
+    /// New `Memory`
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl StorageApi for Memory {
+    type Error = Infallible;
+
+    #[inline]
+    fn get(&self, key: impl AsRef<[u8]>) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.0.get(key.as_ref()).cloned())
+    }
+
+    #[inline]
+    fn batch_get(&self, keys: &[impl AsRef<[u8]>]) -> Result<Vec<Option<Vec<u8>>>, Self::Error> {
+        Ok(keys
+            .iter()
+            .map(|key| self.0.get(key.as_ref()).cloned())
+            .collect())
+    }
+
+    #[inline]
+    fn insert(
+        &mut self,
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+    ) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.0.insert(key.into(), value.into()))
+    }
+
+    #[inline]
+    fn remove(&mut self, key: impl AsRef<[u8]>) -> Result<Option<Vec<u8>>, Self::Error> {
+        Ok(self.0.remove(key.as_ref()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_memory() {
+        let mut storage = Memory::new();
+        assert_eq!(storage.get("key"), Ok(None));
+        assert_eq!(storage.insert("key", "value"), Ok(None));
+        assert_eq!(
+            storage.get("key"),
+            Ok(Some("value".to_owned().into_bytes()))
+        );
+        assert_eq!(storage.insert("key", "value2"), Ok(Some("value".into())));
+        assert_eq!(
+            storage.get("key"),
+            Ok(Some("value2".to_owned().into_bytes()))
+        );
+        assert_eq!(storage.batch_get(&["key"]), Ok(vec![Some("value2".into())]));
+        assert_eq!(storage.remove("key"), Ok(Some("value2".into())));
+        assert_eq!(storage.get("key"), Ok(None));
+    }
+}

--- a/xline/src/storage/mod.rs
+++ b/xline/src/storage/mod.rs
@@ -1,25 +1,24 @@
-/// Storage for KV
-pub(crate) mod kv_store;
-
 /// Storage for Auth
 pub(crate) mod auth_store;
-
 /// Database module
 pub(crate) mod db;
-
-/// Revision module
-pub(crate) mod revision;
-
 /// Index module
 pub(crate) mod index;
-
+/// Storage for KV
+pub(crate) mod kv_store;
 /// KV watcher module
 pub(crate) mod kvwatcher;
-
-/// Request context module
-pub(crate) mod req_ctx;
-
 /// Storage for lease
 pub(crate) mod lease_store;
+/// Memory storage module
+pub(crate) mod memory;
+/// Request context module
+pub(crate) mod req_ctx;
+/// Revision module
+pub(crate) mod revision;
+/// Persistent storage abstraction
+pub(crate) mod storage_api;
 
-pub(crate) use self::{auth_store::AuthStore, kv_store::KvStore, lease_store::LeaseStore};
+pub(crate) use self::{
+    auth_store::AuthStore, kv_store::KvStore, lease_store::LeaseStore, storage_api::StorageApi,
+};

--- a/xline/src/storage/storage_api.rs
+++ b/xline/src/storage/storage_api.rs
@@ -1,0 +1,51 @@
+/// persistent storage abstraction
+pub trait StorageApi: Send + Sync + 'static + std::fmt::Debug {
+    /// Error type returned by storage
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Get value by key from storage
+    ///
+    /// if key found, return `Ok(Some(value))`
+    ///
+    /// if key not found, return `Ok(None)`
+    ///
+    /// # Errors
+    ///
+    /// if error occurs in storage, return `Err(error)`
+    fn get(&self, key: impl AsRef<[u8]>) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Get values by keys from storage
+    ///
+    /// same as `get`, but get multiple keys at once
+    ///
+    /// # Errors
+    ///
+    /// if error occurs in storage, return `Err(error)`
+    fn batch_get(&self, keys: &[impl AsRef<[u8]>]) -> Result<Vec<Option<Vec<u8>>>, Self::Error>;
+
+    /// Insert key-value pair into storage
+    ///
+    /// if key already exists, return `Ok(Some(old_value))`
+    ///
+    /// if key not exists, return `Ok(None)`
+    ///
+    /// # Errors
+    ///
+    /// if error occurs in storage, return `Err(error)`
+    fn insert(
+        &mut self,
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
+    ) -> Result<Option<Vec<u8>>, Self::Error>;
+
+    /// Delete key from storage
+    ///
+    /// if key already exists, return `Ok(Some(old_value))`
+    ///
+    /// if key not exists, return `Ok(None)`
+    ///
+    /// # Errors
+    ///
+    /// if error occurs in storage, return `Err(error)`
+    fn remove(&mut self, key: impl AsRef<[u8]>) -> Result<Option<Vec<u8>>, Self::Error>;
+}

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -7,7 +7,7 @@ use tokio::{
     time::{self, Duration},
 };
 use utils::config::{ClientTimeout, ServerTimeout};
-use xline::{client::Client, server::XlineServer};
+use xline::{client::Client, server::XlineServer, Memory};
 
 /// Cluster
 pub struct Cluster {
@@ -54,6 +54,7 @@ impl Cluster {
             let mut rx = stop_tx.subscribe();
             let listener = self.listeners.remove(&i).unwrap();
             let all_members = self.all_members.clone();
+            let s = Memory::new();
             tokio::spawn(async move {
                 let server = XlineServer::new(
                     name,
@@ -62,6 +63,7 @@ impl Cluster {
                     Self::test_key_pair(),
                     ServerTimeout::default(),
                     ClientTimeout::default(),
+                    s,
                 )
                 .await;
                 let signal = async {


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Abstract a storage layer to make persistent storage easier
* what changes does this pull request make?
Abstract the storage layer as a trait similar to `HashMap`, and use `Mutex<HashMap<Vec<u8>,Vet<u8>>>` to provide a default in-memory implementation
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No