### PR TITLE
bump rust toolchain to 1.67.1 and fix clippy warnings

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CI_RUST_TOOLCHAIN: 1.61.0
+  CI_RUST_TOOLCHAIN: 1.67.1
 
 jobs:
   becnmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on:
   schedule:
     - cron: "00 19 * * *" # run ci periodically at 3 am
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.61.0
+  CI_RUST_TOOLCHAIN: 1.67.1
 
 jobs:
   outdated:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
     branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.61.0
+  CI_RUST_TOOLCHAIN: 1.67.1
 
 jobs:
   coverage:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CI_RUST_TOOLCHAIN: 1.61.0
+  CI_RUST_TOOLCHAIN: 1.67.1
 
 jobs:
   docker:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -2,10 +2,10 @@ name: Validation
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.61.0
+  CI_RUST_TOOLCHAIN: 1.67.1
 
 jobs:
   becnmark:

--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -238,7 +238,7 @@ where
                     return Err(ProposeError::SyncedError("wait sync timeout".to_owned()));
                 }
                 SyncResult::Error(e) => {
-                    return Err(ProposeError::SyncedError(format!("{:?}", e)));
+                    return Err(ProposeError::SyncedError(format!("{e:?}")));
                 }
             }
         }

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -104,6 +104,22 @@
     // clippy::use_debug, debug is allow for debug log
     clippy::verbose_file_reads,
     clippy::wildcard_enum_match_arm,
+
+    // The followings are selected lints from 1.61.0 to 1.67.1
+    clippy::as_ptr_cast_mut,
+    clippy::derive_partial_eq_without_eq,
+    clippy::empty_drop,
+    clippy::empty_structs_with_brackets,
+    clippy::format_push_string,
+    clippy::iter_on_empty_collections,
+    clippy::iter_on_single_items,
+    clippy::large_include_file,
+    clippy::manual_clamp,
+    clippy::suspicious_xor_used_as_pow,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::unused_peekable,
+    clippy::unused_rounding
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/curp/src/server/bg_tasks.rs
+++ b/curp/src/server/bg_tasks.rs
@@ -502,7 +502,7 @@ fn recover_from_spec_pools<C: Command, ExeTx: CmdExeSenderInterface<C>>(
     let recovered_cmds = cmd_cnt
         .into_values()
         // only cmds whose cnt >= 3/4 can be recovered
-        .filter_map(|(cmd, cnt)| (cnt >= superquorum_cnt).then(|| cmd))
+        .filter_map(|(cmd, cnt)| (cnt >= superquorum_cnt).then_some(cmd))
         // dedup in current logs
         .filter(|cmd| {
             // TODO: better dedup mechanism

--- a/curp/src/server/cmd_worker.rs
+++ b/curp/src/server/cmd_worker.rs
@@ -177,8 +177,9 @@ enum ExeMsgToken<C> {
 
 impl<C: Command> ConflictCheck for ExeMsgToken<C> {
     fn is_conflict(&self, other: &Self) -> bool {
-        match (self, other) {
-            (&ExeMsgToken::Cmd(ref cmd1), &ExeMsgToken::Cmd(ref cmd2)) => cmd1.is_conflict(cmd2),
+        #[allow(clippy::pattern_type_mismatch)] // clash with clippy::needless_borrowed_reference
+        match (&self, &other) {
+            (ExeMsgToken::Cmd(ref cmd1), ExeMsgToken::Cmd(ref cmd2)) => cmd1.is_conflict(cmd2),
             // Reset should conflict with all others
             _ => true,
         }

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -168,18 +168,18 @@ impl<C: Command + 'static> Rpc<C> {
                 .layer(f)
                 .add_service(ProtocolServer::new(server))
                 .serve(
-                    format!("0.0.0.0:{}", port)
+                    format!("0.0.0.0:{port}")
                         .parse()
-                        .map_err(|e| ServerError::ParsingError(format!("{}", e)))?,
+                        .map_err(|e| ServerError::ParsingError(format!("{e}")))?,
                 )
                 .await?;
         } else {
             tonic::transport::Server::builder()
                 .add_service(ProtocolServer::new(server))
                 .serve(
-                    format!("0.0.0.0:{}", port)
+                    format!("0.0.0.0:{port}")
                         .parse()
-                        .map_err(|e| ServerError::ParsingError(format!("{}", e)))?,
+                        .map_err(|e| ServerError::ParsingError(format!("{e}")))?,
                 )
                 .await?;
         }
@@ -396,7 +396,7 @@ impl<C: 'static + Command> Protocol<C> {
         let p = request.into_inner();
 
         let cmd: C = p.cmd().map_err(|e| {
-            tonic::Status::invalid_argument(format!("propose cmd decode failed: {}", e))
+            tonic::Status::invalid_argument(format!("propose cmd decode failed: {e}"))
         })?;
 
         async {
@@ -463,8 +463,7 @@ impl<C: 'static + Command> Protocol<C> {
         .map_or_else(
             |err| {
                 Err(tonic::Status::internal(format!(
-                    "encode or decode error, {}",
-                    err
+                    "encode or decode error, {err}",
                 )))
             },
             |resp| Ok(tonic::Response::new(resp)),
@@ -478,7 +477,7 @@ impl<C: 'static + Command> Protocol<C> {
     ) -> Result<tonic::Response<WaitSyncedResponse>, tonic::Status> {
         let ws = request.into_inner();
         let id = ws.id().map_err(|e| {
-            tonic::Status::invalid_argument(format!("wait_synced id decode failed: {}", e))
+            tonic::Status::invalid_argument(format!("wait_synced id decode failed: {e}"))
         })?;
 
         debug!("get wait synced request for {id:?}");
@@ -531,7 +530,7 @@ impl<C: 'static + Command> Protocol<C> {
         };
         debug!("wait synced for {id:?} finishes");
         resp.map(tonic::Response::new)
-            .map_err(|err| tonic::Status::internal(format!("encode or decode error, {}", err)))
+            .map_err(|err| tonic::Status::internal(format!("encode or decode error, {err}")))
     }
 
     /// Handle `AppendEntries` requests
@@ -564,7 +563,7 @@ impl<C: 'static + Command> Protocol<C> {
 
         let mut entries = req
             .entries()
-            .map_err(|e| tonic::Status::internal(format!("encode or decode error, {}", e)))?;
+            .map_err(|e| tonic::Status::internal(format!("encode or decode error, {e}")))?;
 
         // if the request is a heartbeat(heartbeat requests' entries are always empty), don't modify local logs
         if !entries.is_empty() {

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -59,7 +59,7 @@ impl TestTxFilter {
 
 impl TxFilter for TestTxFilter {
     fn filter(&self) -> Option<()> {
-        self.reachable.load(Ordering::Acquire).then(|| ())
+        self.reachable.load(Ordering::Acquire).then_some(())
     }
 
     fn boxed_clone(&self) -> Box<dyn TxFilter> {
@@ -346,7 +346,7 @@ impl CurpGroup {
         let addr = self
             .all
             .iter()
-            .find_map(|(node_id, addr)| (node_id == id).then(|| addr))
+            .find_map(|(node_id, addr)| (node_id == id).then_some(addr))
             .unwrap();
         let addr = format!("http://{}", addr);
         ProtocolClient::connect(addr.clone()).await.unwrap()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.67.1"
 components = ["rustfmt", "clippy", "rust-src"]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -104,6 +104,22 @@
     // clippy::use_debug, debug is allow for debug log
     clippy::verbose_file_reads,
     clippy::wildcard_enum_match_arm,
+
+    // The followings are selected lints from 1.61.0 to 1.67.1
+    clippy::as_ptr_cast_mut,
+    clippy::derive_partial_eq_without_eq,
+    clippy::empty_drop,
+    clippy::empty_structs_with_brackets,
+    clippy::format_push_string,
+    clippy::iter_on_empty_collections,
+    clippy::iter_on_single_items,
+    clippy::large_include_file,
+    clippy::manual_clamp,
+    clippy::suspicious_xor_used_as_pow,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::unused_peekable,
+    clippy::unused_rounding
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/utils/src/std_lock.rs
+++ b/utils/src/std_lock.rs
@@ -18,7 +18,7 @@ impl<T, R> MutexMap<T, R> for Mutex<T> {
     where
         F: FnOnce(MutexGuard<'_, T>) -> R,
     {
-        let lock = self.lock().map_err(|e| format!("{:?}", e))?;
+        let lock = self.lock().map_err(|e| format!("{e:?}"))?;
         Ok(f(lock))
     }
 }
@@ -50,7 +50,7 @@ impl<T, R> RwLockMap<T, R> for RwLock<T> {
     where
         READ: FnOnce(RwLockReadGuard<'_, T>) -> R,
     {
-        let read_guard = self.read().map_err(|e| format!("{:?}", e))?;
+        let read_guard = self.read().map_err(|e| format!("{e:?}"))?;
         Ok(f(read_guard))
     }
 
@@ -59,7 +59,7 @@ impl<T, R> RwLockMap<T, R> for RwLock<T> {
     where
         WRITE: FnOnce(RwLockWriteGuard<'_, T>) -> R,
     {
-        let write_guard = self.write().map_err(|e| format!("{:?}", e))?;
+        let write_guard = self.write().map_err(|e| format!("{e:?}"))?;
         Ok(f(write_guard))
     }
 }

--- a/xline/src/bin/lock_client.rs
+++ b/xline/src/bin/lock_client.rs
@@ -55,7 +55,7 @@ mod test {
     use super::*;
     #[test]
     fn it_works() {
-        let args: ClientArgs = ClientArgs::parse_from(&[
+        let args: ClientArgs = ClientArgs::parse_from([
             "lock_client",
             "--endpoints",
             "http://127.0.0.1:1234",
@@ -69,7 +69,7 @@ mod test {
                 name: "test".to_owned()
             }
         );
-        let args2: ClientArgs = ClientArgs::parse_from(&["lock_client", "unlock", "test"]);
+        let args2: ClientArgs = ClientArgs::parse_from(["lock_client", "unlock", "test"]);
         assert_eq!(args2.endpoints, Vec::<String>::new());
         assert_eq!(
             args2.command,

--- a/xline/src/client/mod.rs
+++ b/xline/src/client/mod.rs
@@ -5,6 +5,7 @@ use etcd_client::{
     AuthClient, Client as EtcdClient, KvClient, LeaseClient, LeaseKeepAliveStream, LeaseKeeper,
     LockClient, WatchClient,
 };
+use itertools::Itertools;
 use utils::config::ClientTimeout;
 use uuid::Uuid;
 
@@ -65,14 +66,8 @@ impl Client {
         use_curp_client: bool,
         timeout: ClientTimeout,
     ) -> Result<Self, ClientError> {
-        let etcd_client = EtcdClient::connect(
-            all_members
-                .iter()
-                .map(|(_, addr)| addr.clone())
-                .collect::<Vec<_>>(),
-            None,
-        )
-        .await?;
+        let etcd_client =
+            EtcdClient::connect(all_members.values().cloned().collect_vec(), None).await?;
         let curp_client = CurpClient::new(all_members, timeout).await;
         Ok(Self {
             name: String::from("client"),

--- a/xline/src/id_gen.rs
+++ b/xline/src/id_gen.rs
@@ -25,7 +25,7 @@ impl IdGenerator {
         let prefix = member_id.overflowing_shl(48).0;
         let mut ts = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|e| panic!("SystemTime before UNIX EPOCH! {}", e))
+            .unwrap_or_else(|e| panic!("SystemTime before UNIX EPOCH! {e}"))
             .as_millis();
         ts &= (u128::MAX.overflowing_shr(88).0); // lower 40 bits (128 - 40)
         ts = ts.overflowing_shl(8).0; // shift left 8 bits

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -104,6 +104,22 @@
     // clippy::use_debug, debug is allow for debug log
     clippy::verbose_file_reads,
     clippy::wildcard_enum_match_arm,
+
+    // The followings are selected lints from 1.61.0 to 1.67.1
+    clippy::as_ptr_cast_mut,
+    clippy::derive_partial_eq_without_eq,
+    clippy::empty_drop,
+    clippy::empty_structs_with_brackets,
+    clippy::format_push_string,
+    clippy::iter_on_empty_collections,
+    clippy::iter_on_single_items,
+    clippy::large_include_file,
+    clippy::manual_clamp,
+    clippy::suspicious_xor_used_as_pow,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::unused_peekable,
+    clippy::unused_rounding
 )]
 #![allow(
     clippy::panic, // allow debug_assert, panic in production code

--- a/xline/src/server/auth_server.rs
+++ b/xline/src/server/auth_server.rs
@@ -117,7 +117,7 @@ where
         let salt = SaltString::generate(&mut OsRng);
         let hashed_password = Pbkdf2
             .hash_password(password, salt.as_ref())
-            .unwrap_or_else(|e| panic!("Failed to hash password: {}", e));
+            .unwrap_or_else(|e| panic!("Failed to hash password: {e}"));
         hashed_password.to_string()
     }
 
@@ -190,7 +190,7 @@ where
             let checked_revision =
                 self.check_password(&request.get_ref().name, &request.get_ref().password)?;
             let mut authenticate_req = request.get_ref().clone();
-            authenticate_req.password = "".to_owned();
+            authenticate_req.password = String::new();
 
             let (res, sync_res) = self
                 .propose(tonic::Request::new(authenticate_req), false)
@@ -230,7 +230,7 @@ where
         }
         let hashed_password = Self::hash_password(user_add_req.password.as_bytes());
         user_add_req.hashed_password = hashed_password;
-        user_add_req.password = "".to_owned();
+        user_add_req.password = String::new();
         self.handle_req(request, false).await
     }
 
@@ -268,7 +268,7 @@ where
         let mut user_change_password_req = request.get_mut();
         let hashed_password = Self::hash_password(user_change_password_req.password.as_bytes());
         user_change_password_req.hashed_password = hashed_password;
-        user_change_password_req.password = "".to_owned();
+        user_change_password_req.password = String::new();
         self.handle_req(request, false).await
     }
 

--- a/xline/src/server/kv_server.rs
+++ b/xline/src/server/kv_server.rs
@@ -117,12 +117,12 @@ where
         let cmd_res = self
             .kv_storage
             .execute(id, wrapper)
-            .map_err(|e| tonic::Status::internal(&format!("Execute failed: {:?}", e)))?;
+            .map_err(|e| tonic::Status::internal(format!("Execute failed: {e:?}")))?;
         let res = Self::parse_response_op(cmd_res.decode().into());
         if let Response::ResponseRange(response) = res {
             Ok(tonic::Response::new(response))
         } else {
-            panic!("Receive wrong response {:?} for RangeRequest", res);
+            panic!("Receive wrong response {res:?} for RangeRequest");
         }
     }
 
@@ -401,7 +401,7 @@ where
         if let Response::ResponsePut(response) = res {
             Ok(tonic::Response::new(response))
         } else {
-            panic!("Receive wrong response {:?} for PutRequest", res);
+            panic!("Receive wrong response {res:?} for PutRequest");
         }
     }
 
@@ -427,7 +427,7 @@ where
         if let Response::ResponseDeleteRange(response) = res {
             Ok(tonic::Response::new(response))
         } else {
-            panic!("Receive wrong response {:?} for DeleteRangeRequest", res);
+            panic!("Receive wrong response {res:?} for DeleteRangeRequest");
         }
     }
 
@@ -454,7 +454,7 @@ where
         if let Response::ResponseTxn(response) = res {
             Ok(tonic::Response::new(response))
         } else {
-            panic!("Receive wrong response {:?} for TxnRequest", res);
+            panic!("Receive wrong response {res:?} for TxnRequest");
         }
     }
 

--- a/xline/src/server/lease_server.rs
+++ b/xline/src/server/lease_server.rs
@@ -88,7 +88,7 @@ where
                                 let _ignore = request.metadata_mut().insert(
                                     "token",
                                     token.parse().unwrap_or_else(|e| {
-                                        panic!("metadata value parse error: {}", e)
+                                        panic!("metadata value parse error: {e}")
                                     }),
                                 );
                             }
@@ -194,8 +194,7 @@ where
                                 })
                                 .map_err(|e| {
                                     tonic::Status::invalid_argument(format!(
-                                        "Keep alive error: {}",
-                                        e
+                                        "Keep alive error: {e}",
                                     ))
                                 });
                             assert!(
@@ -331,9 +330,8 @@ where
         if self.is_leader() {
             // TODO wait applied index
             let time_to_live_req = request.into_inner();
-            let lease = match self.lease_storage.look_up(time_to_live_req.id) {
-                Some(lease) => lease,
-                None => return Err(tonic::Status::not_found("Lease not found")),
+            let Some(lease) = self.lease_storage.look_up(time_to_live_req.id) else {
+                return Err(tonic::Status::not_found("Lease not found"));
             };
 
             let keys = time_to_live_req

--- a/xline/src/server/lock_server.rs
+++ b/xline/src/server/lock_server.rs
@@ -134,7 +134,7 @@ where
 
     /// Crate txn for try acquire lock
     fn create_acquire_txn(prefix: &str, lease_id: i64) -> TxnRequest {
-        let key = format!("{}{:x}", prefix, lease_id);
+        let key = format!("{prefix}{lease_id:x}");
         #[allow(clippy::as_conversions)] // this cast is always safe
         let cmp = Compare {
             result: CompareResult::Equal as i32,
@@ -219,7 +219,7 @@ where
                     })),
                 })
                 .await
-                .unwrap_or_else(|e| panic!("failed to send watch request: {}", e));
+                .unwrap_or_else(|e| panic!("failed to send watch request: {e}"));
 
             let mut response_stream = watch_client.watch(request_stream).await?.into_inner();
             while let Some(watch_res) = response_stream.message().await? {
@@ -255,7 +255,7 @@ where
     async fn lease_grant(&self, token: Option<String>) -> Result<i64, tonic::Status> {
         let lease_id = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|e| panic!("SystemTime before UNIX EPOCH! {}", e))
+            .unwrap_or_else(|e| panic!("SystemTime before UNIX EPOCH! {e}"))
             .as_secs()
             .cast(); // TODO: generate lease unique id
         let lease_grant_req = LeaseGrantRequest {
@@ -293,7 +293,7 @@ where
         };
 
         let prefix = format!("{}/", String::from_utf8_lossy(&lock_req.name).into_owned());
-        let key = format!("{}{:x}", prefix, lease_id);
+        let key = format!("{prefix}{lease_id:x}");
 
         let txn = Self::create_acquire_txn(&prefix, lease_id);
         let (cmd_res, sync_res) = self.propose(txn, token.clone(), false).await?;

--- a/xline/src/server/watch_server.rs
+++ b/xline/src/server/watch_server.rs
@@ -150,9 +150,7 @@ where
 
     /// Handle `WatchCreateRequest`
     async fn handle_watch_create(&mut self, req: WatchCreateRequest) {
-        let watch_id = if let Some(id) = self.validate_watch_id(req.watch_id) {
-            id
-        } else {
+        let Some(watch_id) = self.validate_watch_id(req.watch_id) else {
             let result = Err(tonic::Status::already_exists(format!(
                 "Watch ID {} has already been used",
                 req.watch_id
@@ -178,8 +176,7 @@ where
         );
         assert!(
             self.active_watch_ids.insert(watch_id),
-            "WatchId {} already exists in watcher_map",
-            watch_id
+            "WatchId {watch_id} already exists in watcher_map",
         );
 
         let response = WatchResponse {

--- a/xline/src/storage/auth_store/perms.rs
+++ b/xline/src/storage/auth_store/perms.rs
@@ -75,7 +75,7 @@ impl TokenOperate for JwtTokenManager {
     fn assign(&self, username: &str, revision: i64) -> Result<String, Self::Error> {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap_or_else(|e| panic!("SystemTime before UNIX EPOCH! {}", e))
+            .unwrap_or_else(|e| panic!("SystemTime before UNIX EPOCH! {e}"))
             .as_secs();
         let claims = TokenClaims {
             username: username.to_owned(),

--- a/xline/src/storage/auth_store/store.rs
+++ b/xline/src/storage/auth_store/store.rs
@@ -459,7 +459,7 @@ mod test {
         let req2 = RequestWithToken::new(
             AuthUserAddRequest {
                 name: "u".to_owned(),
-                password: "".to_owned(),
+                password: String::new(),
                 hashed_password: "123".to_owned(),
                 options: None,
             }

--- a/xline/src/storage/db.rs
+++ b/xline/src/storage/db.rs
@@ -32,7 +32,7 @@ where
         let key = revision.encode_to_vec();
         let value = kv.encode_to_vec();
         let _prev_val = storage.insert(key, value).map_err(|e| {
-            ExecuteError::InvalidCommand(format!("Failed to insert revision {:?}: {}", revision, e))
+            ExecuteError::InvalidCommand(format!("Failed to insert revision {revision:?}: {e}"))
         })?;
         Ok(())
     }
@@ -47,10 +47,7 @@ where
         let values = storage
             .batch_get(&keys)
             .map_err(|e| {
-                ExecuteError::InvalidCommand(format!(
-                    "Failed to get revisions {:?}: {}",
-                    revisions, e
-                ))
+                ExecuteError::InvalidCommand(format!("Failed to get revisions {revisions:?}: {e}"))
             })?
             .into_iter()
             .flatten()
@@ -62,8 +59,7 @@ where
             .collect::<Result<_, _>>()
             .map_err(|e| {
                 ExecuteError::InvalidCommand(format!(
-                    "Failed to decode revisions {:?}: {}",
-                    revisions, e
+                    "Failed to decode revisions {revisions:?}: {e}",
                 ))
             })?;
         Ok(kvs)
@@ -77,26 +73,23 @@ where
         let mut storage = self.storage.write();
         let prev_kvs: Vec<KeyValue> = revisions
             .iter()
-            .map(|&(ref prev_rev, _)| {
+            .map(|&(prev_rev, _)| {
                 let key = prev_rev.encode_to_vec();
                 let value = storage.get(key).map_err(|e| {
                     ExecuteError::InvalidCommand(format!(
-                        "Failed to get revision {:?}: {}",
-                        prev_rev, e
+                        "Failed to get revision {prev_rev:?}: {e}",
                     ))
                 })?;
                 if let Some(value) = value {
                     let kv = KeyValue::decode(value.as_slice()).map_err(|e| {
                         ExecuteError::InvalidCommand(format!(
-                            "Failed to decode revision {:?}: {}",
-                            prev_rev, e
+                            "Failed to decode revision {prev_rev:?}: {e}",
                         ))
                     })?;
                     Ok(kv)
                 } else {
                     Err(ExecuteError::InvalidCommand(format!(
-                        "Failed to get revision {:?} from DB",
-                        prev_rev
+                        "Failed to get revision {prev_rev:?} from DB",
                     )))
                 }
             })
@@ -118,8 +111,7 @@ where
                 let value = del_kv.encode_to_vec();
                 let _prev_val = storage.insert(key, value).map_err(|e| {
                     ExecuteError::InvalidCommand(format!(
-                        "Failed to insert revision {:?}: {}",
-                        new_rev, e
+                        "Failed to insert revision {new_rev:?}: {e}",
                     ))
                 });
                 Ok(del_kv)

--- a/xline/src/storage/index.rs
+++ b/xline/src/storage/index.rs
@@ -196,7 +196,7 @@ impl IndexOperate for Index {
                 revisions.push(new_rev);
                 new_rev
             } else {
-                panic!("Get empty revision list for key {:?}", key);
+                panic!("Get empty revision list for key {key:?}");
             }
         } else {
             let new_rev = KeyRevision::new(revision, 1, revision, sub_revision);

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -552,7 +552,7 @@ where
     /// Sync a vec of requests
     async fn sync_requests(&self, id: &ProposeId) -> Result<i64, ExecuteError> {
         let ctxes = self.sp_exec_pool.lock().remove(id).unwrap_or_else(|| {
-            panic!("Failed to get speculative execution propose id {:?}", id);
+            panic!("Failed to get speculative execution propose id {id:?}");
         });
         if ctxes.iter().any(RequestCtx::met_err) {
             return Ok(self.revision());
@@ -654,7 +654,7 @@ where
         if req.lease != 0 {
             self.attach(req.lease, kv.key.as_slice())
                 .await // already checked, lease is not 0
-                .unwrap_or_else(|e| panic!("unexpected error from lease Attach: {}", e));
+                .unwrap_or_else(|e| panic!("unexpected error from lease Attach: {e}"));
         }
         let event = Event {
             #[allow(clippy::as_conversions)] // This cast is always valid

--- a/xline/src/storage/lease_store/mod.rs
+++ b/xline/src/storage/lease_store/mod.rs
@@ -403,7 +403,7 @@ impl LeaseStoreBackend {
             header: Some(self.header_gen.gen_header_without_revision()),
             id: req.id,
             ttl: req.ttl,
-            error: "".to_owned(),
+            error: String::new(),
         })
     }
 
@@ -424,7 +424,7 @@ impl LeaseStoreBackend {
     /// Sync `RequestWithToken`
     async fn sync_request(&self, id: &ProposeId) -> i64 {
         let ctx = self.sp_exec_pool.lock().remove(id).unwrap_or_else(|| {
-            panic!("Failed to get speculative execution propose id {:?}", id);
+            panic!("Failed to get speculative execution propose id {id:?}");
         });
         if ctx.met_err() {
             return self.header_gen.revision();


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Dependency error

* what changes does this pull request make?
bump rust toolchain to 1.67.1

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)