### PR TITLE
[Curp] Log entry persistency

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,15 +1,18 @@
 # Usage
 
 ## Configurations
+
 The Xline configuration file is written in toml format and the default path is /etc/xline_server.conf. If you need to change the path of the configuration file, you can set it via the environment variable XLINE_SERVER_CONFIG.
 
 The configuration file has four sections, as follows:
+
 1. cluster section: contains information about curp cluster, including basic information, cluster member configuration, curp server timeout settings (optional), curp client timeout settings (optional).
 2. log section: contains the Xline log-related configuration, where path is required, rotation (optional, default value is 'daily'), level (optional, default value is 'info')
 3. trace section: contains the jaeger's trace mode (online or offline), trace level and the log directory in offline mode
 4. auth section: contains the address of the key pair required for authentication
 
 A minimum config file looks like:
+
 ```toml
 [cluster]
 name = 'node1'                  # server identity
@@ -35,9 +38,10 @@ auth_public_key = '/etc/xline/public_key.pem'
 auth_private_key = '/etc/xline/private_key.pem'
 ```
 
-For tuning and development purpose, the cluster section provides two subsections, server_timeout, and client_timeout, with the following definitions and default values.
+For tuning and development purpose, the cluster section provides two subsections, curp_cfg, and client_timeout, with the following definitions and default values.
+
 ```toml
-[cluster.server_timeout]
+[cluster.curp_config]
 heartbeat_interval = '300ms'    # the curp heartbeat(tick) interval of which default value is 300ms
 wait_synced_timeout = '5s'      # server wait synced timeout
 rpc_timeout = '50ms'            # the rpc timeout of which default value is 50ms
@@ -56,8 +60,10 @@ retry_timeout = '50ms'          # the rpc retry interval, of which the default i
 ```
 
 ## Boot up an Xline cluster
+
 1. Download binary from [release]() page.
 2. Use the following command to start cluster:
+
     ```bash
     # Run in 3 terminals. If you want more logs, add `RUST_LOG=debug` before the command.
 
@@ -67,8 +73,10 @@ retry_timeout = '50ms'          # the rpc retry interval, of which the default i
 
     ./xline --name node3 --members node1=127.0.0.1:2379,node2=127.0.0.1:2380,node3=127.0.0.1:2381
     ```
+
 3. Download or build `etcdctl` from [etcd](https://github.com/etcd-io/etcd) project.
 4. Use `etcdctl` to operate the cluster:
+
     ```bash
     etcdctl --endpoints=http://127.0.0.1:2379 put foo bar
 

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -34,6 +34,7 @@ tracing-opentelemetry = "0.18.0"
 flume = "0.10.14"
 indexmap = "1.9.2"
 tower = { version = "0.4.13", features = ["filter"] }
+engine = { path = "../engine" }
 
 [dev-dependencies]
 itertools = "0.10.3"

--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -116,4 +116,7 @@ where
 
     /// Reset the command executor to the initial state
     async fn reset(&self);
+
+    /// Index of the last log entry that has been successfully applied to the command executor
+    fn last_applied(&self) -> usize;
 }

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -282,6 +282,7 @@ impl<C: 'static + Command> CurpNode<C> {
         let cmd_board = Arc::new(RwLock::new(CommandBoard::new()));
         let spec_pool = Arc::new(Mutex::new(SpeculativePool::new()));
         let uncommitted_pool = Arc::new(Mutex::new(UncommittedPool::new()));
+        let last_applied = cmd_executor.last_applied();
 
         let storage = Arc::new(RocksDBStorage::new(&curp_cfg.data_dir)?);
 
@@ -331,6 +332,7 @@ impl<C: 'static + Command> CurpNode<C> {
                 log_tx,
                 voted_for,
                 entries,
+                last_applied,
             ))
         };
 

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -122,7 +122,7 @@ impl<C: Command + 'static> Rpc<C> {
             match CurpNode::new(id, is_leader, others, executor, curp_cfg, tx_filter).await {
                 Ok(n) => n,
                 Err(err) => {
-                    panic!("failed to create curp service， {err}");
+                    panic!("failed to create curp service, {err}");
                 }
             };
 

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -23,6 +23,9 @@ pub(super) struct Log<C: Command> {
     /// Index of highest log entry known to be committed
     pub(super) commit_index: usize,
     /// Index of highest log entry applied to state machine
+    /// Note this `last_applied` is a little bit different from the one in command executor
+    /// in that it means the index of the last log sent to the `cmd_worker`(may not be executed yet)
+    /// while the `last_applied` in command executor means index of the last log entry that has been successfully applied to the command executor.
     pub(super) last_applied: usize,
     /// Tx to send log entries to persist task
     log_tx: mpsc::UnboundedSender<LogEntry<C>>,

--- a/curp/src/server/raw_curp/state.rs
+++ b/curp/src/server/raw_curp/state.rs
@@ -137,7 +137,7 @@ impl LeaderState {
         }
 
         *match_index = index;
-        debug!("follower {}'s match_index to {match_index}", id);
+        debug!("follower {}'s match_index updated to {match_index}", id);
 
         let next_index = self
             .next_index

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -32,6 +32,7 @@ impl<C: 'static + Command> RawCurp<C> {
         let uncommitted_pool = Arc::new(Mutex::new(UncommittedPool::new()));
         let (sync_tx, _sync_rx) = mpsc::unbounded_channel();
         let (calibrate_tx, _rx) = mpsc::unbounded_channel();
+        let (log_tx, _log_rx) = mpsc::unbounded_channel();
         Self::new(
             "S0".to_owned(),
             others,
@@ -43,6 +44,7 @@ impl<C: 'static + Command> RawCurp<C> {
             Box::new(exe_tx),
             sync_tx,
             calibrate_tx,
+            log_tx,
         )
     }
 

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -40,7 +40,7 @@ impl<C: 'static + Command> RawCurp<C> {
             cmd_board,
             spec_pool,
             uncommitted_pool,
-            Arc::new(ServerTimeout::default()),
+            Arc::new(CurpConfig::default()),
             Box::new(exe_tx),
             sync_tx,
             calibrate_tx,

--- a/curp/src/server/storage/mod.rs
+++ b/curp/src/server/storage/mod.rs
@@ -1,8 +1,19 @@
-use std::error::Error;
-
 use async_trait::async_trait;
+use engine::error::EngineError;
+use thiserror::Error;
 
 use crate::{cmd::Command, log_entry::LogEntry, message::ServerId};
+
+/// Storage layer error
+#[derive(Error, Debug)]
+pub(super) enum StorageError {
+    /// Serialize or deserialize error
+    #[error("bincode error, {0}")]
+    Bincode(#[from] bincode::Error),
+    /// Rocksdb error
+    #[error("internal error, {0}")]
+    Internal(#[from] EngineError),
+}
 
 /// Curp storage api
 #[async_trait]
@@ -11,16 +22,16 @@ pub(super) trait StorageApi: Send + Sync {
     type Command: Command;
 
     /// Put `voted_for` in storage, must be flushed on disk before returning
-    async fn flush_voted_for(&self, term: u64, voted_for: ServerId) -> Result<(), Box<dyn Error>>;
+    async fn flush_voted_for(&self, term: u64, voted_for: ServerId) -> Result<(), StorageError>;
 
     /// Put log entries in storage
-    async fn put_log_entry(&self, entry: LogEntry<Self::Command>) -> Result<(), Box<dyn Error>>;
+    async fn put_log_entry(&self, entry: LogEntry<Self::Command>) -> Result<(), StorageError>;
 
     /// Recover from persisted storage
     /// Return `voted_for` and all log entries
     async fn recover(
         &self,
-    ) -> Result<(Option<(u64, ServerId)>, Vec<LogEntry<Self::Command>>), Box<dyn Error>>;
+    ) -> Result<(Option<(u64, ServerId)>, Vec<LogEntry<Self::Command>>), StorageError>;
 }
 
 /// `RocksDB` storage implementation

--- a/curp/src/server/storage/mod.rs
+++ b/curp/src/server/storage/mod.rs
@@ -1,0 +1,27 @@
+use std::error::Error;
+
+use async_trait::async_trait;
+
+use crate::{cmd::Command, log_entry::LogEntry, message::ServerId};
+
+/// Curp storage api
+#[async_trait]
+pub(super) trait StorageApi: Send + Sync {
+    /// Command
+    type Command: Command;
+
+    /// Put `voted_for` in storage, must be flushed on disk before returning
+    async fn flush_voted_for(&self, term: u64, voted_for: ServerId) -> Result<(), Box<dyn Error>>;
+
+    /// Put log entries in storage
+    async fn put_log_entry(&self, entry: LogEntry<Self::Command>) -> Result<(), Box<dyn Error>>;
+
+    /// Recover from persisted storage
+    /// Return `voted_for` and all log entries
+    async fn recover(
+        &self,
+    ) -> Result<(Option<(u64, ServerId)>, Vec<LogEntry<Self::Command>>), Box<dyn Error>>;
+}
+
+/// `RocksDB` storage implementation
+pub(super) mod rocksdb;

--- a/curp/src/server/storage/rocksdb.rs
+++ b/curp/src/server/storage/rocksdb.rs
@@ -1,0 +1,144 @@
+use std::{marker::PhantomData, path::Path};
+
+use async_trait::async_trait;
+use engine::{error::EngineError, rocksdb_engine::RocksEngine, StorageEngine, WriteOperation};
+use thiserror::Error;
+
+use super::StorageApi;
+use crate::{cmd::Command, log_entry::LogEntry, message::ServerId};
+
+/// Key for persisted state
+const VOTE_FOR: &[u8] = b"VoteFor";
+
+/// Column family name for curp storage
+const CF: &str = "curp";
+
+/// `RocksDBStorage` error
+#[derive(Error, Debug)]
+pub(in crate::server) enum Error {
+    /// Serialize or deserialize error
+    #[error("bincode error")]
+    Bincode(#[from] bincode::Error),
+    /// Rocksdb error
+    #[error("rocksdb error")]
+    RocksDB(#[from] EngineError),
+}
+
+/// `RocksDB` storage implementation
+pub(in crate::server) struct RocksDBStorage<C> {
+    /// DB handle
+    db: RocksEngine,
+    /// Phantom
+    phantom: PhantomData<C>,
+}
+
+#[async_trait]
+impl<C: 'static + Command> StorageApi for RocksDBStorage<C> {
+    /// Command
+    type Command = C;
+
+    async fn flush_voted_for(
+        &self,
+        term: u64,
+        voted_for: ServerId,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = bincode::serialize(&(term, voted_for))?;
+        let op = WriteOperation::new_put(CF, VOTE_FOR.to_vec(), bytes);
+        self.db.write_batch(vec![op], true)?;
+
+        Ok(())
+    }
+
+    async fn put_log_entry(
+        &self,
+        entry: LogEntry<Self::Command>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let bytes = bincode::serialize(&entry)?;
+        let op = WriteOperation::new_put(CF, entry.index.to_be_bytes().to_vec(), bytes);
+        self.db.write_batch(vec![op], false)?;
+
+        Ok(())
+    }
+
+    async fn recover(
+        &self,
+    ) -> Result<(Option<(u64, ServerId)>, Vec<LogEntry<Self::Command>>), Box<dyn std::error::Error>>
+    {
+        let voted_for = self
+            .db
+            .get(CF, VOTE_FOR)?
+            .map(|bytes| bincode::deserialize::<(u64, ServerId)>(&bytes))
+            .transpose()?;
+
+        let mut entries = vec![];
+        let mut prev_index = 0;
+        for (k, v) in self.db.get_all(CF)? {
+            // we can identify whether a kv is state or entry by the key length
+            if k.len() == VOTE_FOR.len() {
+                continue;
+            }
+            let entry: LogEntry<C> = bincode::deserialize(&v)?;
+            #[allow(clippy::integer_arithmetic)] // won't overflow
+            if entry.index != prev_index + 1 {
+                // break when logs are no longer consistent
+                break;
+            }
+            prev_index = entry.index;
+            entries.push(entry);
+        }
+
+        Ok((voted_for, entries))
+    }
+}
+
+impl<C> RocksDBStorage<C> {
+    /// Create a new `RocksDBStorage`
+    pub(in crate::server) fn new(dir: impl AsRef<Path>) -> Result<Self, Error> {
+        let db = RocksEngine::new(dir, &[CF])?;
+        Ok(Self {
+            db,
+            phantom: PhantomData,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{error::Error, sync::Arc};
+
+    use tokio::fs::remove_dir_all;
+
+    use super::*;
+    use crate::test_utils::{random_id, sleep_secs, test_cmd::TestCommand};
+
+    #[tokio::test]
+    async fn create_and_recover() -> Result<(), Box<dyn Error>> {
+        let db_dir = format!("/tmp/curp-{}", random_id());
+
+        {
+            let s = RocksDBStorage::<TestCommand>::new(&db_dir)?;
+            s.flush_voted_for(1, "S2".to_string()).await?;
+            s.flush_voted_for(3, "S1".to_string()).await?;
+            let entry0 = LogEntry::new(1, 3, Arc::new(TestCommand::default()));
+            let entry1 = LogEntry::new(2, 3, Arc::new(TestCommand::default()));
+            let entry2 = LogEntry::new(3, 3, Arc::new(TestCommand::default()));
+            s.put_log_entry(entry0).await?;
+            s.put_log_entry(entry1).await?;
+            s.put_log_entry(entry2).await?;
+            sleep_secs(2).await;
+        }
+
+        {
+            let s = RocksDBStorage::<TestCommand>::new(&db_dir)?;
+            let (voted_for, entries) = s.recover().await?;
+            assert_eq!(voted_for, Some((3, "S1".to_string())));
+            assert_eq!(entries[0].index, 1);
+            assert_eq!(entries[1].index, 2);
+            assert_eq!(entries[2].index, 3);
+        }
+
+        remove_dir_all(db_dir).await?;
+
+        Ok(())
+    }
+}

--- a/curp/src/test_utils/mod.rs
+++ b/curp/src/test_utils/mod.rs
@@ -15,6 +15,8 @@
 
 use std::time::Duration;
 
+use madsim::rand::{distributions::Alphanumeric, thread_rng, Rng};
+
 pub(crate) mod test_cmd;
 
 pub(crate) async fn sleep_millis(n: u64) {
@@ -23,4 +25,12 @@ pub(crate) async fn sleep_millis(n: u64) {
 
 pub(crate) async fn sleep_secs(n: u64) {
     tokio::time::sleep(Duration::from_secs(n)).await;
+}
+
+pub(crate) fn random_id() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(4)
+        .map(char::from)
+        .collect()
 }

--- a/curp/src/test_utils/mod.rs
+++ b/curp/src/test_utils/mod.rs
@@ -30,7 +30,7 @@ pub(crate) async fn sleep_secs(n: u64) {
 pub(crate) fn random_id() -> String {
     thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(4)
+        .take(8)
         .map(char::from)
         .collect()
 }

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -3,6 +3,7 @@ use std::{
     error::Error,
     fmt::Display,
     iter,
+    path::PathBuf,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -18,7 +19,11 @@ use parking_lot::Mutex;
 use tokio::{net::TcpListener, runtime::Runtime, sync::mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
 use tracing::debug;
-use utils::config::{ClientTimeout, ServerTimeout};
+use utils::config::{
+    default_candidate_timeout_ticks, default_follower_timeout_ticks, default_heartbeat_interval,
+    default_retry_timeout, default_rpc_timeout, default_server_wait_synced_timeout, ClientTimeout,
+    CurpConfig,
+};
 
 use crate::common::{
     random_id,
@@ -154,10 +159,17 @@ impl CurpGroup {
                         others.into_iter().collect(),
                         listener,
                         ce,
-                        Arc::new(ServerTimeout::default()),
+                        Arc::new(CurpConfig::new(
+                            default_heartbeat_interval(),
+                            default_server_wait_synced_timeout(),
+                            default_retry_timeout(),
+                            default_rpc_timeout(),
+                            default_follower_timeout_ticks(),
+                            default_candidate_timeout_ticks(),
+                            PathBuf::from(storage_path_c),
+                        )),
                         Some(Box::new(TestTxFilter::new(Arc::clone(&switch_c)))),
                         Some(reachable_layer),
-                        storage_path_c,
                     ));
                 });
 
@@ -274,10 +286,17 @@ impl CurpGroup {
                 others.into_iter().collect(),
                 listener,
                 ce,
-                Arc::new(ServerTimeout::default()),
+                Arc::new(CurpConfig::new(
+                    default_heartbeat_interval(),
+                    default_server_wait_synced_timeout(),
+                    default_retry_timeout(),
+                    default_rpc_timeout(),
+                    default_follower_timeout_ticks(),
+                    default_candidate_timeout_ticks(),
+                    PathBuf::from(storage_path),
+                )),
                 Some(Box::new(TestTxFilter::new(Arc::clone(&switch_c)))),
                 Some(reachable_layer),
-                storage_path,
             ));
         });
 

--- a/curp/tests/common/mod.rs
+++ b/curp/tests/common/mod.rs
@@ -31,7 +31,7 @@ pub async fn sleep_secs(n: u64) {
 pub(crate) fn random_id() -> String {
     thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(4)
+        .take(8)
         .map(char::from)
         .collect()
 }

--- a/curp/tests/common/mod.rs
+++ b/curp/tests/common/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{env, io, time::Duration};
 
+use madsim::rand::{distributions::Alphanumeric, thread_rng, Rng};
 use thiserror::Error;
 use tracing_subscriber::fmt::time::{uptime, OffsetTime, Uptime};
 
@@ -25,4 +26,12 @@ pub async fn sleep_millis(n: u64) {
 
 pub async fn sleep_secs(n: u64) {
     tokio::time::sleep(Duration::from_secs(n)).await;
+}
+
+pub(crate) fn random_id() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(4)
+        .map(char::from)
+        .collect()
 }

--- a/xline/Cargo.toml
+++ b/xline/Cargo.toml
@@ -23,7 +23,7 @@ event-listener = "2.5.2"
 jsonwebtoken = "8.1.1"
 itertools = "0.10.3"
 utils = { path = "../utils", features = ["parking_lot"] }
-engine = { path = "../engine"}
+engine = { path = "../engine" }
 log = "0.4.17"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-contrib = { version = "0.10.0", features = [
@@ -61,3 +61,4 @@ tonic-build = "0.7.2"
 
 [dev-dependencies]
 mockall = "0.11.3"
+rand = "0.8.5"

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -227,6 +227,11 @@ where
 
     // TODO
     async fn reset(&self) {}
+
+    // TODO
+    fn last_applied(&self) -> usize {
+        0
+    }
 }
 
 /// Command to run consensus protocol

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -115,7 +115,7 @@ impl Cluster {
 fn random_id() -> String {
     thread_rng()
         .sample_iter(&Alphanumeric)
-        .take(4)
+        .take(8)
         .map(char::from)
         .collect()
 }

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -1,12 +1,13 @@
 use std::collections::{BTreeMap, HashMap};
 
 use jsonwebtoken::{DecodingKey, EncodingKey};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use tokio::{
     net::TcpListener,
     sync::broadcast::{self, Sender},
     time::{self, Duration},
 };
-use utils::config::{ClientTimeout, ServerTimeout, StorageConfig};
+use utils::config::{ClientTimeout, CurpConfig, StorageConfig};
 use xline::{client::Client, server::XlineServer, storage::db::DBProxy};
 
 /// Cluster
@@ -62,7 +63,10 @@ impl Cluster {
                     all_members,
                     is_leader,
                     Self::test_key_pair(),
-                    ServerTimeout::default(),
+                    CurpConfig {
+                        data_dir: format!("/tmp/curp-{}", random_id()).into(),
+                        ..Default::default()
+                    },
                     ClientTimeout::default(),
                     db,
                 )
@@ -106,4 +110,12 @@ impl Cluster {
         let decoding_key = DecodingKey::from_rsa_pem(public_key).unwrap();
         Some((encoding_key, decoding_key))
     }
+}
+
+fn random_id() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(4)
+        .map(char::from)
+        .collect()
 }

--- a/xline_server.conf
+++ b/xline_server.conf
@@ -8,7 +8,7 @@ node2 = '127.0.0.1:2380'
 node3 = '127.0.0.1:2381'
 
 # curp server timeout settings
-[cluster.server_timeout]
+[cluster.curp_config]
 # The hearbeat(tick) interval between curp server nodes, default value is 150ms
 # heartbeat_interval = '150ms'
 


### PR DESCRIPTION
Based on #178 

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Persist log entries and `voted_for`.

* what changes does this pull request make?
This PR also rename `ServerTimeout` config to `CurpConfig` since now it will contain data dir.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)