### PR TITLE
Use anonymous generic parameter instead of dynamic object of connect

### DIFF
--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -12,8 +12,9 @@ use crate::{
     error::ProposeError,
     message::ServerId,
     rpc::{
-        self, connect::ConnectApi, FetchLeaderRequest, ProposeRequest, SyncError, SyncResult,
-        WaitSyncedRequest,
+        self,
+        connect::{Connect, ConnectApi},
+        FetchLeaderRequest, ProposeRequest, SyncError, SyncResult, WaitSyncedRequest,
     },
 };
 
@@ -22,7 +23,7 @@ pub struct Client<C: Command> {
     /// Current leader and term
     state: RwLock<State>,
     /// All servers's `Connect`
-    connects: HashMap<ServerId, Arc<dyn ConnectApi>>,
+    connects: HashMap<ServerId, Arc<Connect>>,
     /// Curp client timeout settings
     timeout: ClientTimeout,
     /// To keep Command type

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -30,7 +30,7 @@ pub trait TxFilter: Send + Sync + Debug {
 pub(crate) async fn connect(
     addrs: HashMap<ServerId, String>,
     tx_filter: Option<Box<dyn TxFilter>>,
-) -> HashMap<ServerId, Arc<dyn ConnectApi>> {
+) -> HashMap<ServerId, Arc<Connect>> {
     futures::future::join_all(addrs.into_iter().map(|(id, mut addr)| async move {
         // Addrs must start with "http" to communicate with the server
         if !addr.starts_with("http://") {
@@ -46,7 +46,7 @@ pub(crate) async fn connect(
     .into_iter()
     .map(|(id, addr, conn)| {
         debug!("successfully establish connection with {addr}");
-        let connect: Arc<dyn ConnectApi> = Arc::new(Connect {
+        let connect = Arc::new(Connect {
             id: id.clone(),
             rpc_connect: RwLock::new(conn),
             addr,


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Use anonymous generic parameter instead of dynamic object of connect. Static generic is faster than static genericl

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)