### PR TITLE
add some necessary config to boot up an xline cluster in benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -2,6 +2,8 @@ name: Benchmark
 
 on:
   workflow_dispatch: {}
+  schedule:
+    - cron: "00 00 * * 1"
 
 env:
   CI_RUST_TOOLCHAIN: 1.67.1

--- a/benchmark/src/args.rs
+++ b/benchmark/src/args.rs
@@ -36,7 +36,7 @@ pub enum Commands {
         /// Value size
         #[clap(long, default_value_t = 8)]
         val_size: usize,
-        /// Total number of keys
+        /// Total number of requests
         #[clap(long, default_value_t = 10000)]
         total: usize,
         /// Key space size

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -319,6 +319,7 @@ impl<C: 'static + Command> CurpNode<C> {
             Arc::clone(&uncommitted_pool),
             Arc::clone(&cmd_board),
             Arc::clone(&shutdown_trigger),
+            usize::from(curp_cfg.cmd_workers),
         );
 
         // create curp state machine

--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -20,9 +20,9 @@ use tokio::{net::TcpListener, runtime::Runtime, sync::mpsc};
 use tokio_stream::wrappers::TcpListenerStream;
 use tracing::debug;
 use utils::config::{
-    default_candidate_timeout_ticks, default_follower_timeout_ticks, default_heartbeat_interval,
-    default_retry_timeout, default_rpc_timeout, default_server_wait_synced_timeout, ClientTimeout,
-    CurpConfig,
+    default_candidate_timeout_ticks, default_cmd_workers, default_follower_timeout_ticks,
+    default_heartbeat_interval, default_retry_timeout, default_rpc_timeout,
+    default_server_wait_synced_timeout, ClientTimeout, CurpConfig,
 };
 
 use crate::common::{
@@ -167,6 +167,7 @@ impl CurpGroup {
                             default_follower_timeout_ticks(),
                             default_candidate_timeout_ticks(),
                             PathBuf::from(storage_path_c),
+                            default_cmd_workers(),
                         )),
                         Some(Box::new(TestTxFilter::new(Arc::clone(&switch_c)))),
                         Some(reachable_layer),
@@ -294,6 +295,7 @@ impl CurpGroup {
                     default_follower_timeout_ticks(),
                     default_candidate_timeout_ticks(),
                     PathBuf::from(storage_path),
+                    default_cmd_workers(),
                 )),
                 Some(Box::new(TestTxFilter::new(Arc::clone(&switch_c)))),
                 Some(reachable_layer),

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -52,7 +52,7 @@ run_xline() {
     --server-wait-synced-timeout 10s \
     --client-wait-synced-timeout 10s \
     --client_propose_timeout 5s \
-    --log-level debug"
+    --cmd-workers 16"
 
     if [ ${1} -eq 1 ]; then
         cmd="${cmd} --is-leader"

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -58,8 +58,8 @@ run_xline() {
         cmd="${cmd} --is-leader"
     fi
 
-    docker exec -e RUST_LOG=debug -d node${1} ${cmd}
-    echo "docker exec -e RUST_LOG=debug -d node${1} ${cmd}"
+    docker exec -e RUST_LOG=curp,xline. -d node${1} ${cmd}
+    echo "docker exec -e RUST_LOG=curp,xline -d node${1} ${cmd}"
 }
 
 # run etcd node by index

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -44,7 +44,11 @@ benchmark_cmd() {
 run_xline() {
     cmd="/usr/local/bin/xline \
     --name node${1} \
-    --members ${MEMBERS}"
+    --members ${MEMBERS} \
+    --storage-engine rocksdb \
+    --data-dir /usr/local/xline/data-dir \
+    --retry-timeout 250ms \
+    --rpc-timeout 250ms"
 
     if [ ${1} -eq 1 ]; then
         cmd="${cmd} --is-leader"
@@ -112,7 +116,12 @@ stop_cluster() {
 # stop all containers
 stop_all() {
     echo stopping
-    docker stop $(docker ps -a -q)
+    for name in "node1" "node2" "node3" "client"; do
+        docker_id=$(docker ps -qf "name=${name}")
+        if [ -n "$docker_id" ]; then
+            docker stop $docker_id
+        fi
+    done
     sleep 1
     echo stopped
 }

--- a/scripts/quick_start.sh
+++ b/scripts/quick_start.sh
@@ -39,7 +39,12 @@ run_cluster() {
 # stop all containers
 stop_all() {
     echo stopping
-    docker stop node1 node2 node3 node4
+    for name in "node1" "node2" "node3" "node4"; do
+        docker_id=$(docker ps -qf "name=${name}")
+        if [ -n "$docker_id" ]; then
+            docker stop $docker_id
+        fi
+    done
     sleep 1
     echo stopped
 }

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -133,6 +133,10 @@ pub struct CurpConfig {
     /// Curp storage path
     #[serde(default = "default_curp_data_dir")]
     pub data_dir: PathBuf,
+
+    /// Number of command execute workers
+    #[serde(default = "default_cmd_workers")]
+    pub cmd_workers: u8,
 }
 
 /// default heartbeat interval
@@ -198,10 +202,18 @@ pub fn default_curp_data_dir() -> PathBuf {
     PathBuf::from("/var/lib/curp")
 }
 
+/// default number of execute workers
+#[must_use]
+#[inline]
+pub fn default_cmd_workers() -> u8 {
+    8
+}
+
 impl CurpConfig {
     /// Create a new server timeout
     #[must_use]
     #[inline]
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         heartbeat_interval: Duration,
         wait_synced_timeout: Duration,
@@ -210,6 +222,7 @@ impl CurpConfig {
         follower_timeout_ticks: u8,
         candidate_timeout_ticks: u8,
         data_dir: PathBuf,
+        cmd_workers: u8,
     ) -> Self {
         Self {
             heartbeat_interval,
@@ -219,6 +232,7 @@ impl CurpConfig {
             follower_timeout_ticks,
             candidate_timeout_ticks,
             data_dir,
+            cmd_workers,
         }
     }
 }
@@ -234,6 +248,7 @@ impl Default for CurpConfig {
             follower_timeout_ticks: default_follower_timeout_ticks(),
             candidate_timeout_ticks: default_candidate_timeout_ticks(),
             data_dir: default_curp_data_dir(),
+            cmd_workers: default_cmd_workers(),
         }
     }
 }
@@ -569,6 +584,7 @@ mod tests {
             default_follower_timeout_ticks(),
             default_candidate_timeout_ticks(),
             default_curp_data_dir(),
+            default_cmd_workers(),
         );
 
         let client_timeout = ClientTimeout::new(

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -142,56 +142,56 @@ pub struct CurpConfig {
 /// default heartbeat interval
 #[must_use]
 #[inline]
-pub fn default_heartbeat_interval() -> Duration {
+pub const fn default_heartbeat_interval() -> Duration {
     Duration::from_millis(300)
 }
 
 /// default wait synced timeout
 #[must_use]
 #[inline]
-pub fn default_server_wait_synced_timeout() -> Duration {
+pub const fn default_server_wait_synced_timeout() -> Duration {
     Duration::from_secs(5)
 }
 
 /// default retry timeout
 #[must_use]
 #[inline]
-pub fn default_retry_timeout() -> Duration {
+pub const fn default_retry_timeout() -> Duration {
     Duration::from_millis(50)
 }
 
 /// default rpc timeout
 #[must_use]
 #[inline]
-pub fn default_rpc_timeout() -> Duration {
+pub const fn default_rpc_timeout() -> Duration {
     Duration::from_millis(50)
 }
 
 /// default candidate timeout ticks
 #[must_use]
 #[inline]
-pub fn default_candidate_timeout_ticks() -> u8 {
+pub const fn default_candidate_timeout_ticks() -> u8 {
     2
 }
 
 /// default client wait synced timeout
 #[must_use]
 #[inline]
-pub fn default_client_wait_synced_timeout() -> Duration {
+pub const fn default_client_wait_synced_timeout() -> Duration {
     Duration::from_secs(2)
 }
 
 /// default client propose timeout
 #[must_use]
 #[inline]
-pub fn default_propose_timeout() -> Duration {
+pub const fn default_propose_timeout() -> Duration {
     Duration::from_secs(1)
 }
 
 /// default follower timeout
 #[must_use]
 #[inline]
-pub fn default_follower_timeout_ticks() -> u8 {
+pub const fn default_follower_timeout_ticks() -> u8 {
     5
 }
 
@@ -205,7 +205,7 @@ pub fn default_curp_data_dir() -> PathBuf {
 /// default number of execute workers
 #[must_use]
 #[inline]
-pub fn default_cmd_workers() -> u8 {
+pub const fn default_cmd_workers() -> u8 {
     8
 }
 
@@ -357,7 +357,7 @@ pub mod level_format {
 /// default log level
 #[must_use]
 #[inline]
-pub fn default_log_level() -> LevelConfig {
+pub const fn default_log_level() -> LevelConfig {
     LevelConfig::INFO
 }
 
@@ -420,7 +420,7 @@ pub mod rotation_format {
 /// default log rotation strategy
 #[must_use]
 #[inline]
-pub fn default_rotation() -> RotationConfig {
+pub const fn default_rotation() -> RotationConfig {
     RotationConfig::Daily
 }
 

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -123,7 +123,7 @@ use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{fmt::format, prelude::*};
 use utils::{
     config::{
-        default_candidate_timeout_ticks, default_client_wait_synced_timeout,
+        default_candidate_timeout_ticks, default_client_wait_synced_timeout, default_cmd_workers,
         default_follower_timeout_ticks, default_heartbeat_interval, default_log_level,
         default_propose_timeout, default_retry_timeout, default_rotation, default_rpc_timeout,
         default_server_wait_synced_timeout, file_appender, AuthConfig, ClientTimeout,
@@ -209,6 +209,9 @@ struct ServerArgs {
     data_dir: PathBuf,
     /// Curp directory
     curp_dir: Option<PathBuf>,
+    /// Curp command workers count
+    #[clap(long, default_value_t = default_cmd_workers())]
+    cmd_workers: u8,
 }
 
 impl From<ServerArgs> for XlineServerConfig {
@@ -227,6 +230,7 @@ impl From<ServerArgs> for XlineServerConfig {
                 path.push("curp");
                 path
             }),
+            args.cmd_workers,
         );
 
         let storage = match args.storage_engine.as_str() {


### PR DESCRIPTION
We set 100ms to simulate the latency on the WAN, but our retry timeout and rpc timeout is only 50ms. Therefore,we need to extent the rpc timeout and retry timeout

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)