### PR TITLE
Curp snapshot

### DIFF
--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -35,6 +35,12 @@ flume = "0.10.14"
 indexmap = "1.9.2"
 tower = { version = "0.4.13", features = ["filter"] }
 engine = { path = "../engine" }
+async-stream = "0.3.4"
+chrono = { version = "0.4.24", default-features = false, features = [
+  "clock",
+  "std",
+] }
+uuid = { version = "1.3.1", features = ["v4"] }
 
 [dev-dependencies]
 itertools = "0.10.3"

--- a/curp/proto/message.proto
+++ b/curp/proto/message.proto
@@ -71,10 +71,25 @@ message VoteResponse {
     repeated bytes spec_pool = 3;
 }
 
+message InstallSnapshotRequest {
+    uint64 term = 1;
+    string leader_id = 2;
+    uint64 last_included_index = 3;
+    uint64 last_included_term = 4;
+    uint64 offset = 5;
+    bytes data = 6;
+    bool done = 7;
+}
+
+message InstallSnapshotResponse {
+    uint64 term = 1;
+}
+
 service Protocol {
     rpc Propose (ProposeRequest) returns (ProposeResponse);
     rpc WaitSynced (WaitSyncedRequest) returns (WaitSyncedResponse);
     rpc AppendEntries (AppendEntriesRequest) returns (AppendEntriesResponse);
     rpc Vote (VoteRequest) returns (VoteResponse);
     rpc FetchLeader (FetchLeaderRequest) returns (FetchLeaderResponse);
+    rpc InstallSnapshot (stream InstallSnapshotRequest) returns (InstallSnapshotResponse);
 }

--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Display, hash::Hash};
 
 use async_trait::async_trait;
+use engine::engine_api::SnapshotApi;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 use crate::log_entry::LogIndex;
@@ -114,9 +115,15 @@ where
     /// Execute the after_sync callback
     async fn after_sync(&self, cmd: &C, index: LogIndex) -> Result<C::ASR, Self::Error>;
 
-    /// Reset the command executor to the initial state
-    async fn reset(&self);
-
     /// Index of the last log entry that has been successfully applied to the command executor
     fn last_applied(&self) -> Result<LogIndex, Self::Error>;
+
+    /// Take a snapshot
+    async fn snapshot(&self) -> Result<Box<dyn SnapshotApi>, Self::Error>;
+
+    /// Reset the command executor using the snapshot or to the initial state if None
+    async fn reset(
+        &self,
+        snapshot: Option<(Box<dyn SnapshotApi>, LogIndex)>,
+    ) -> Result<(), Self::Error>;
 }

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -170,5 +170,8 @@ mod log_entry;
 /// Protobuf generated types that are used in RPC
 mod rpc;
 
+/// Snapshot
+mod snapshot;
+
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/curp/src/rpc/mod.rs
+++ b/curp/src/rpc/mod.rs
@@ -8,8 +8,8 @@ pub(crate) use self::proto::{
     protocol_server::Protocol,
     wait_synced_response::{Success, SyncResult as SyncResultRaw},
     AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest, FetchLeaderResponse,
-    ProposeRequest, ProposeResponse, VoteRequest, VoteResponse, WaitSyncedRequest,
-    WaitSyncedResponse,
+    InstallSnapshotRequest, InstallSnapshotResponse, ProposeRequest, ProposeResponse, VoteRequest,
+    VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
 };
 use crate::{
     cmd::{Command, ProposeId},
@@ -330,5 +330,12 @@ impl VoteResponse {
             .iter()
             .map(|cmd| bincode::deserialize(cmd))
             .collect()
+    }
+}
+
+impl InstallSnapshotResponse {
+    /// Create a new snapshot response
+    pub(crate) fn new(term: u64) -> Self {
+        Self { term }
     }
 }

--- a/curp/src/server/storage/mod.rs
+++ b/curp/src/server/storage/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use engine::error::EngineError;
+use engine::{engine_api::SnapshotApi, error::EngineError};
 use thiserror::Error;
 
 use crate::{cmd::Command, log_entry::LogEntry, ServerId};
@@ -32,6 +32,9 @@ pub(super) trait StorageApi: Send + Sync {
     async fn recover(
         &self,
     ) -> Result<(Option<(u64, ServerId)>, Vec<LogEntry<Self::Command>>), StorageError>;
+
+    /// Initialize a new snapshot
+    async fn new_snapshot(&self) -> Result<Box<dyn SnapshotApi>, StorageError>;
 }
 
 /// `RocksDB` storage implementation

--- a/curp/src/snapshot.rs
+++ b/curp/src/snapshot.rs
@@ -1,0 +1,36 @@
+use std::fmt::Debug;
+
+use engine::engine_api::SnapshotApi;
+
+/// Snapshot
+#[derive(Debug)]
+pub(crate) struct Snapshot {
+    /// Snapshot metadata
+    pub(crate) meta: SnapshotMeta,
+    /// Snapshot
+    inner: Box<dyn SnapshotApi>,
+}
+
+impl Snapshot {
+    /// Create a new snapshot
+    pub(crate) fn new(meta: SnapshotMeta, snapshot: Box<dyn SnapshotApi>) -> Self {
+        Self {
+            meta,
+            inner: snapshot,
+        }
+    }
+
+    /// Into inner snapshot
+    pub(crate) fn into_inner(self) -> Box<dyn SnapshotApi> {
+        self.inner
+    }
+}
+
+/// Metadata for snapshot
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SnapshotMeta {
+    /// Last included index
+    pub(crate) last_included_index: u64,
+    /// Last included term
+    pub(crate) last_included_term: u64,
+}

--- a/curp/tests/common/test_cmd.rs
+++ b/curp/tests/common/test_cmd.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::HashMap,
     fmt::Display,
+    io::{self, Cursor, Read, SeekFrom, Write},
     sync::{
         atomic::{AtomicU64, Ordering},
         Arc,
@@ -14,6 +15,7 @@ use curp::{
     cmd::{Command, CommandExecutor, ConflictCheck, ProposeId},
     LogIndex,
 };
+use engine::{engine_api::SnapshotApi, memory_engine::MemorySnapshot};
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -189,12 +191,36 @@ impl CommandExecutor<TestCommand> for TestCE {
         Ok(index)
     }
 
-    async fn reset(&self) {
-        self.store.lock().clear();
-    }
-
     fn last_applied(&self) -> Result<LogIndex, ExecuteError> {
         Ok(self.last_applied.load(Ordering::Relaxed))
+    }
+
+    async fn snapshot(&self) -> Result<Box<dyn SnapshotApi>, Self::Error> {
+        let mut ss = MemorySnapshot::default();
+        let buf = bincode::serialize(&*self.store.lock()).unwrap();
+        ss.write_all(&buf).await.unwrap();
+        debug!("{} takes a snapshot", self.server_id);
+        Ok(Box::new(ss))
+    }
+
+    async fn reset(
+        &self,
+        snapshot: Option<(Box<dyn SnapshotApi>, LogIndex)>,
+    ) -> Result<(), Self::Error> {
+        let Some((mut snapshot, index)) = snapshot else {
+            self.last_applied.store(0, Ordering::Relaxed);
+            self.store.lock().clear();
+            return Ok(());
+        };
+        self.last_applied
+            .store(index.numeric_cast(), Ordering::Relaxed);
+        snapshot.rewind().unwrap();
+        let mut buffer = vec![0; snapshot.size().numeric_cast()];
+        snapshot.read_exact(&mut buffer).await.unwrap();
+        let mut store_w = self.store.lock();
+        *store_w = bincode::deserialize(buffer.as_slice()).unwrap();
+        debug!("{:?}", store_w);
+        Ok(())
     }
 }
 

--- a/engine/src/engine_api.rs
+++ b/engine/src/engine_api.rs
@@ -58,7 +58,7 @@ impl<'a> WriteOperation<'a> {
 
 /// This trait is a abstraction of the snapshot, We can Read/Write the snapshot like a file.
 #[async_trait::async_trait]
-pub trait SnapshotApi: Send + Sync {
+pub trait SnapshotApi: Send + Sync + std::fmt::Debug {
     /// Get the size of the snapshot
     fn size(&self) -> u64;
 

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -9,6 +9,7 @@ use curp::{
     },
     LogIndex,
 };
+use engine::engine_api::SnapshotApi;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
@@ -265,10 +266,22 @@ where
         Ok(res)
     }
 
-    async fn reset(&self) {
-        self.persistent
-            .reset()
-            .unwrap_or_else(|e| panic!("reset backend failed, {e:?}"));
+    #[allow(clippy::todo)]
+    async fn reset(
+        &self,
+        snapshot: Option<(Box<dyn SnapshotApi>, LogIndex)>,
+    ) -> Result<(), Self::Error> {
+        if snapshot.is_none() {
+            self.persistent.reset()
+        } else {
+            todo!("apply snapshot");
+        }
+    }
+
+    /// Todo
+    #[allow(clippy::todo)]
+    async fn snapshot(&self) -> Result<Box<dyn SnapshotApi>, Self::Error> {
+        todo!("snapshot");
     }
 
     fn last_applied(&self) -> Result<LogIndex, ExecuteError> {


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Implement snapshot of curp. Based on #224.

Note that without compaction, the snapshot will never be triggered. Compaction will be next PR. As a result, the test is lacking and will be added in next PR.

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)