### PR TITLE
Fix [Bug]: gc panic during a benchmark  #206

### DIFF
--- a/curp/src/server/gc.rs
+++ b/curp/src/server/gc.rs
@@ -157,7 +157,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(500)).await;
         let spec = spec.lock();
         assert_eq!(spec.pool.len(), 1);
-        assert_eq!(spec.pool.get_index(0).unwrap().0, cmd3.id());
+        assert!(spec.pool.contains_key(cmd3.id()));
     }
 
     // To verify #206 is fixed

--- a/curp/src/server/spec_pool.rs
+++ b/curp/src/server/spec_pool.rs
@@ -1,6 +1,5 @@
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
-use indexmap::IndexMap;
 use parking_lot::Mutex;
 use tracing::{debug, warn};
 
@@ -13,14 +12,14 @@ pub(super) type SpecPoolRef<C> = Arc<Mutex<SpeculativePool<C>>>;
 #[derive(Debug)]
 pub(super) struct SpeculativePool<C> {
     /// Store
-    pub(super) pool: IndexMap<ProposeId, Arc<C>>,
+    pub(super) pool: HashMap<ProposeId, Arc<C>>,
 }
 
 impl<C: Command + 'static> SpeculativePool<C> {
     /// Create a new speculative pool
     pub(super) fn new() -> Self {
         Self {
-            pool: IndexMap::new(),
+            pool: HashMap::new(),
         }
     }
 


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Panic in gc

* what changes does this pull request make?
The cause of this bug: spec pool is also modified in cmd worker when a cmd finished after sync. So it's possible that the `last_checked_len` > `spec.len()`. So, instead of recording the length, we now record all keys in spec pool. Admittedly, the cloning of all keys in spec pool will take more time, but I think it's not a big issue since spec pool is usually small.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)