### PR TITLE
Use LogIndex for log index

### DIFF
--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -10,12 +10,12 @@ use utils::{config::ClientTimeout, parking_lot_lock::RwLockMap};
 use crate::{
     cmd::Command,
     error::ProposeError,
-    message::ServerId,
     rpc::{
         self,
         connect::{Connect, ConnectApi},
         FetchLeaderRequest, ProposeRequest, SyncError, SyncResult, WaitSyncedRequest,
     },
+    ServerId,
 };
 
 /// Protocol client

--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, hash::Hash};
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use crate::message::LogIndex;
+use crate::log_entry::LogIndex;
 
 /// Command to execute on the server side
 #[async_trait]

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -146,8 +146,11 @@
     )
 )]
 
-pub use message::LogIndex;
+pub use log_entry::LogIndex;
 pub use rpc::{connect::TxFilter, ProtocolServer};
+
+/// Server Id
+pub(crate) type ServerId = String;
 
 /// Client side, sending requests and determining requests' state
 pub mod client;
@@ -160,9 +163,6 @@ pub mod error;
 
 /// The command to be executed
 pub mod cmd;
-
-/// Message sent between servers and clients
-mod message;
 
 /// Log Entry
 mod log_entry;

--- a/curp/src/log_entry.rs
+++ b/curp/src/log_entry.rs
@@ -2,20 +2,23 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
+/// Log Index
+pub type LogIndex = u64;
+
 /// Log entry
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct LogEntry<C> {
     /// Term
     pub(crate) term: u64,
     /// Index
-    pub(crate) index: usize,
+    pub(crate) index: LogIndex,
     /// The Command
     pub(crate) cmd: Arc<C>,
 }
 
 impl<C> LogEntry<C> {
     /// Create a new `LogEntry`
-    pub(super) fn new(index: usize, term: u64, cmd: Arc<C>) -> Self {
+    pub(super) fn new(index: LogIndex, term: u64, cmd: Arc<C>) -> Self {
         Self { term, index, cmd }
     }
 }

--- a/curp/src/message.rs
+++ b/curp/src/message.rs
@@ -1,6 +1,0 @@
-/// Log Index
-pub type LogIndex = u64;
-
-/// Server Id
-// TODO: replace server id with a hashable generic
-pub(crate) type ServerId = String;

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -9,12 +9,12 @@ use utils::tracing::Inject;
 
 use crate::{
     error::ProposeError,
-    message::ServerId,
     rpc::{
         proto::protocol_client::ProtocolClient, AppendEntriesRequest, AppendEntriesResponse,
         FetchLeaderRequest, FetchLeaderResponse, ProposeRequest, ProposeResponse, VoteRequest,
         VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
     },
+    ServerId,
 };
 
 /// Connect will call filter(request) before it sends out a request

--- a/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
+++ b/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
@@ -12,7 +12,10 @@ use std::{
 use tracing::{debug, error};
 
 use super::CEEvent;
-use crate::cmd::{Command, ProposeId};
+use crate::{
+    cmd::{Command, ProposeId},
+    LogIndex,
+};
 
 /// CE task
 pub(super) struct Task<C> {
@@ -27,7 +30,7 @@ pub(super) enum TaskType<C> {
     /// Execute a cmd
     SpecExe(Arc<C>),
     /// After sync a cmd
-    AS(Arc<C>, usize),
+    AS(Arc<C>, LogIndex),
     /// Reset the CE
     Reset,
 }
@@ -95,7 +98,7 @@ enum AsState {
     /// Not Synced yet
     NotSynced,
     /// Is ready to do after sync
-    AfterSyncReady(usize),
+    AfterSyncReady(LogIndex),
     /// Is doing after syncing
     AfterSyncing,
     /// Has been after synced

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -10,13 +10,12 @@ use self::curp_node::{CurpError, CurpNode};
 use crate::{
     cmd::{Command, CommandExecutor},
     error::ServerError,
-    message::ServerId,
     rpc::{
         AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest, FetchLeaderResponse,
         ProposeRequest, ProposeResponse, ProtocolServer, VoteRequest, VoteResponse,
         WaitSyncedRequest, WaitSyncedResponse,
     },
-    TxFilter,
+    ServerId, TxFilter,
 };
 
 /// Command worker to do execution and after sync

--- a/curp/src/server/raw_curp/state.rs
+++ b/curp/src/server/raw_curp/state.rs
@@ -7,7 +7,7 @@ use madsim::rand::{thread_rng, Rng};
 use tracing::debug;
 
 use super::Role;
-use crate::message::ServerId;
+use crate::{LogIndex, ServerId};
 
 /// Curp state
 #[derive(Debug)]
@@ -48,9 +48,9 @@ pub(super) struct CandidateState<C> {
 #[derive(Debug)]
 pub(super) struct LeaderState {
     /// For each server, index of the next log entry to send to that server
-    next_index: HashMap<ServerId, usize>,
+    next_index: HashMap<ServerId, LogIndex>,
     /// For each server, index of highest log entry known to be replicated on server
-    match_index: HashMap<ServerId, usize>,
+    match_index: HashMap<ServerId, LogIndex>,
     /// Servers that are being calibrated by the leader
     pub(super) calibrating: HashSet<ServerId>,
 }
@@ -92,8 +92,8 @@ impl State {
 impl LeaderState {
     /// Create a `LeaderState`
     pub(super) fn new(
-        next_index: HashMap<ServerId, usize>,
-        match_index: HashMap<ServerId, usize>,
+        next_index: HashMap<ServerId, LogIndex>,
+        match_index: HashMap<ServerId, LogIndex>,
     ) -> Self {
         Self {
             next_index,
@@ -103,7 +103,7 @@ impl LeaderState {
     }
 
     /// Get `next_index` for server
-    pub(super) fn get_next_index(&self, id: &ServerId) -> usize {
+    pub(super) fn get_next_index(&self, id: &ServerId) -> LogIndex {
         *self
             .next_index
             .get(id)
@@ -111,7 +111,7 @@ impl LeaderState {
     }
 
     /// Get `match_index` for server
-    pub(super) fn get_match_index(&self, id: &ServerId) -> usize {
+    pub(super) fn get_match_index(&self, id: &ServerId) -> LogIndex {
         *self
             .match_index
             .get(id)
@@ -119,7 +119,7 @@ impl LeaderState {
     }
 
     /// Update `next_index` for server
-    pub(super) fn update_next_index(&mut self, id: &ServerId, index: usize) {
+    pub(super) fn update_next_index(&mut self, id: &ServerId, index: LogIndex) {
         *self
             .next_index
             .get_mut(id)
@@ -127,7 +127,7 @@ impl LeaderState {
     }
 
     /// Update `match_index` for server, will update `next_index` if possible
-    pub(super) fn update_match_index(&mut self, id: &ServerId, index: usize) {
+    pub(super) fn update_match_index(&mut self, id: &ServerId, index: LogIndex) {
         let match_index = self
             .match_index
             .get_mut(id)

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -15,6 +15,7 @@ use crate::{
         spec_pool::SpeculativePool,
     },
     test_utils::{sleep_millis, test_cmd::TestCommand},
+    LogIndex,
 };
 
 // Hooks for tests
@@ -23,7 +24,7 @@ impl<C: 'static + Command> RawCurp<C> {
         self.st.read().role
     }
 
-    pub(crate) fn commit_index(&self) -> usize {
+    pub(crate) fn commit_index(&self) -> LogIndex {
         self.log.read().commit_index
     }
 
@@ -59,7 +60,7 @@ impl<C: 'static + Command> RawCurp<C> {
     }
 
     /// Add a new cmd to the log, will return log entry index
-    pub(crate) fn push_cmd(&self, cmd: Arc<C>) -> usize {
+    pub(crate) fn push_cmd(&self, cmd: Arc<C>) -> LogIndex {
         let st_r = self.st.read();
         let mut log_w = self.log.write();
         log_w.push_cmd(st_r.term, cmd)

--- a/curp/src/server/storage/mod.rs
+++ b/curp/src/server/storage/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use engine::error::EngineError;
 use thiserror::Error;
 
-use crate::{cmd::Command, log_entry::LogEntry, message::ServerId};
+use crate::{cmd::Command, log_entry::LogEntry, ServerId};
 
 /// Storage layer error
 #[derive(Error, Debug)]

--- a/curp/src/server/storage/rocksdb.rs
+++ b/curp/src/server/storage/rocksdb.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use engine::{rocksdb_engine::RocksEngine, StorageEngine, WriteOperation};
 
 use super::{StorageApi, StorageError};
-use crate::{cmd::Command, log_entry::LogEntry, message::ServerId};
+use crate::{cmd::Command, log_entry::LogEntry, ServerId};
 
 /// Key for persisted state
 const VOTE_FOR: &[u8] = b"VoteFor";

--- a/curp/src/test_utils/test_cmd.rs
+++ b/curp/src/test_utils/test_cmd.rs
@@ -9,7 +9,6 @@ use std::{
 };
 
 use async_trait::async_trait;
-use clippy_utilities::NumericCast;
 use itertools::Itertools;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
@@ -20,8 +19,7 @@ use tracing::debug;
 
 use crate::{
     cmd::{Command, CommandExecutor, ConflictCheck, ProposeId},
-    message::ServerId,
-    LogIndex,
+    LogIndex, ServerId,
 };
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -266,8 +264,7 @@ impl CommandExecutor<TestCommand> for TestCESimple {
         if cmd.as_should_fail {
             return Err(ExecuteError("fail".to_owned()));
         }
-        self.last_applied
-            .store(index.numeric_cast(), Ordering::Relaxed);
+        self.last_applied.store(index, Ordering::Relaxed);
 
         debug!("{} call cmd({}) after sync", self.server_id, cmd.id());
         Ok(index)

--- a/curp/tests/common/test_cmd.rs
+++ b/curp/tests/common/test_cmd.rs
@@ -185,8 +185,7 @@ impl CommandExecutor<TestCommand> for TestCE {
         self.after_sync_sender
             .send((cmd.clone(), index))
             .expect("failed to send after sync msg");
-        self.last_applied
-            .store(index.numeric_cast(), Ordering::Relaxed);
+        self.last_applied.store(index, Ordering::Relaxed);
         Ok(index)
     }
 


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Use `LogIndex`(u64) for log index. We previously use `usize` for log index. `usize` may have different size on different machines, which may result in unexpected bugs.

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)