### PR TITLE
Curp log compaction

### DIFF
--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -148,6 +148,7 @@
 
 pub use log_entry::LogIndex;
 pub use rpc::{connect::TxFilter, ProtocolServer};
+pub use snapshot::SnapshotAllocator;
 
 /// Server Id
 pub(crate) type ServerId = String;

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -118,7 +118,7 @@ pub(crate) trait ConnectApi: Send + Sync + 'static {
         &self,
         term: u64,
         leader_id: ServerId,
-        mut snapshot: Snapshot,
+        snapshot: Snapshot,
     ) -> Result<tonic::Response<InstallSnapshotResponse>, ProposeError>;
 
     /// Send `FetchReadStateRequest`

--- a/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
+++ b/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
@@ -55,7 +55,7 @@ pub(in crate::server) struct Task<C> {
 }
 
 /// Task Type
-pub(in crate::server) enum TaskType<C> {
+pub(super) enum TaskType<C> {
     /// Execute a cmd
     SpecExe(Arc<C>),
     /// After sync a cmd

--- a/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
+++ b/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
@@ -55,7 +55,7 @@ pub(in crate::server) struct Task<C> {
 }
 
 /// Task Type
-pub(super) enum TaskType<C> {
+pub(in crate::server) enum TaskType<C> {
     /// Execute a cmd
     SpecExe(Arc<C>),
     /// After sync a cmd

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -106,7 +106,9 @@ async fn cmd_worker<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
             TaskType::Snapshot(meta, tx) => match ce.snapshot().await {
                 Ok(snapshot) => {
                     debug_assert_eq!(ce.last_applied().unwrap(), meta.last_included_index); // sanity check
-                    if tx.send(Snapshot::new(meta, snapshot)).is_err() {
+                    let snapshot = Snapshot::new(meta, snapshot);
+                    debug!("{} takes a snapshot, {snapshot:?}", curp.id());
+                    if tx.send(snapshot).is_err() {
                         error!("snapshot oneshot closed");
                     }
                     true

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -303,6 +303,7 @@ impl<C: 'static + Command> Log<C> {
             .entries
             .front()
             .map_or(false, |e| e.index <= compact_from)
+            & self.batch_index.front().is_some()
         {
             let e = self.entries.pop_front().unwrap();
             let _ig_i = self.batch_index.pop_front().unwrap();

--- a/curp/src/server/storage/mod.rs
+++ b/curp/src/server/storage/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use engine::{error::EngineError, snapshot_api::SnapshotProxy};
+use engine::error::EngineError;
 use thiserror::Error;
 
 use crate::{cmd::Command, log_entry::LogEntry, ServerId};
@@ -32,9 +32,6 @@ pub(super) trait StorageApi: Send + Sync {
     async fn recover(
         &self,
     ) -> Result<(Option<(u64, ServerId)>, Vec<LogEntry<Self::Command>>), StorageError>;
-
-    /// Initialize a new snapshot
-    async fn new_snapshot(&self) -> Result<SnapshotProxy, StorageError>;
 }
 
 /// `RocksDB` storage implementation

--- a/curp/src/snapshot.rs
+++ b/curp/src/snapshot.rs
@@ -1,5 +1,6 @@
-use std::fmt::Debug;
+use std::{error::Error, fmt::Debug};
 
+use async_trait::async_trait;
 use engine::snapshot_api::SnapshotProxy;
 
 /// Snapshot
@@ -30,4 +31,12 @@ pub(crate) struct SnapshotMeta {
     pub(crate) last_included_index: u64,
     /// Last included term
     pub(crate) last_included_term: u64,
+}
+
+/// The snapshot allocation is handled by the upper-level application
+#[allow(clippy::module_name_repetitions)] // it's re-exported in lib
+#[async_trait]
+pub trait SnapshotAllocator: Send + Sync {
+    /// Allocate a new snapshot
+    async fn allocate_new_snapshot(&self) -> Result<SnapshotProxy, Box<dyn Error>>;
 }

--- a/curp/src/test_utils/test_cmd.rs
+++ b/curp/src/test_utils/test_cmd.rs
@@ -357,7 +357,7 @@ impl TestCESimple {
     }
 }
 
-static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
 
 fn next_id() -> ProposeId {
     ProposeId::new(NEXT_ID.fetch_add(1, Ordering::AcqRel).to_string())

--- a/curp/tests/common/test_cmd.rs
+++ b/curp/tests/common/test_cmd.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 use tokio::{sync::mpsc, time::sleep};
 use tracing::debug;
 
-static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(0));
+static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
 
 fn next_id() -> u64 {
     NEXT_ID.fetch_add(1, Ordering::SeqCst)
@@ -200,6 +200,11 @@ impl CommandExecutor<TestCommand> for TestCE {
                 .expect("failed to send after sync msg");
         }
         self.last_applied.store(index, Ordering::Relaxed);
+        debug!(
+            "{} after sync cmd({}), index: {index}",
+            self.server_id,
+            cmd.id()
+        );
         Ok(index)
     }
 

--- a/curp/tests/server_recovery.rs
+++ b/curp/tests/server_recovery.rs
@@ -398,8 +398,9 @@ async fn recovery_after_compaction() {
     {
         let node = group.nodes.get_mut(&node_id).unwrap();
         let store = node.store.lock();
-        for i in 0..50 {
-            assert_eq!(store[&i], i);
+        for i in 0..50_u32 {
+            let kv = i.to_be_bytes().to_vec();
+            assert_eq!(store[&kv], kv);
         }
     }
 

--- a/engine/src/engine_api.rs
+++ b/engine/src/engine_api.rs
@@ -108,7 +108,7 @@ pub trait StorageEngine: Send + Sync + 'static + std::fmt::Debug {
     ///
     /// # Errors
     /// Return `EngineError` if met some errors when applying the snapshot
-    fn apply_snapshot(
+    async fn apply_snapshot(
         &self,
         snapshot: SnapshotProxy,
         tables: &[&'static str],

--- a/engine/src/memory_engine.rs
+++ b/engine/src/memory_engine.rs
@@ -131,7 +131,7 @@ impl StorageEngine for MemoryEngine {
     }
 
     #[inline]
-    fn apply_snapshot(
+    async fn apply_snapshot(
         &self,
         snapshot: SnapshotProxy,
         _tables: &[&'static str],
@@ -264,7 +264,10 @@ mod test {
         new_snapshot.write_all(&buf).await.unwrap();
 
         let engine_2 = MemoryEngine::new(&TESTTABLES).unwrap();
-        assert!(engine_2.apply_snapshot(new_snapshot, &TESTTABLES).is_ok());
+        assert!(engine_2
+            .apply_snapshot(new_snapshot, &TESTTABLES)
+            .await
+            .is_ok());
 
         let value = engine_2.get("kv", "key").unwrap();
         assert_eq!(value, Some("value".into()));

--- a/engine/src/snapshot_api/rocks_snapshot.rs
+++ b/engine/src/snapshot_api/rocks_snapshot.rs
@@ -395,11 +395,7 @@ impl SnapshotApi for RocksSnapshot {
 
     #[inline]
     async fn clean(&mut self) -> std::io::Result<()> {
-        for snap_file in &self.snap_files {
-            let path = self.dir.join(&snap_file.filename);
-            tokio::fs::remove_file(path).await?;
-        }
-        Ok(())
+        tokio::fs::remove_dir_all(&self.dir).await
     }
 }
 

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -184,6 +184,11 @@ pub struct CurpConfig {
     #[builder(default = "default_gc_interval()")]
     #[serde(with = "duration_format", default = "default_gc_interval")]
     pub gc_interval: Duration,
+
+    /// Number of log entires to keep in memory
+    #[builder(default = "default_log_entries_cap()")]
+    #[serde(default = "default_log_entries_cap")]
+    pub log_entries_cap: usize,
 }
 
 /// default heartbeat interval
@@ -285,6 +290,13 @@ pub const fn default_gc_interval() -> Duration {
     Duration::from_secs(20)
 }
 
+/// default number of log entries to keep in memory
+#[must_use]
+#[inline]
+pub const fn default_log_entries_cap() -> usize {
+    5000
+}
+
 impl Default for CurpConfig {
     #[inline]
     fn default() -> Self {
@@ -300,6 +312,7 @@ impl Default for CurpConfig {
             data_dir: default_curp_data_dir(),
             cmd_workers: default_cmd_workers(),
             gc_interval: default_gc_interval(),
+            log_entries_cap: default_log_entries_cap(),
         }
     }
 }
@@ -605,7 +618,7 @@ mod tests {
             heartbeat_interval = '200ms'
             wait_synced_timeout = '100ms'
             rpc_timeout = '100ms'
-            retry_timeout = '100us'
+            retry_timeout = '100ms'
 
             [cluster.client_timeout]
             retry_timeout = '5s'
@@ -631,7 +644,7 @@ mod tests {
         let curp_config = CurpConfigBuilder::default()
             .heartbeat_interval(Duration::from_millis(200))
             .wait_synced_timeout(Duration::from_millis(100))
-            .retry_timeout(Duration::from_micros(100))
+            .retry_timeout(Duration::from_millis(100))
             .rpc_timeout(Duration::from_millis(100))
             .build()
             .unwrap();

--- a/xline/src/client/restore.rs
+++ b/xline/src/client/restore.rs
@@ -34,7 +34,8 @@ pub async fn restore(
     }
 
     let restore_rocks_engine = RocksEngine::new(data_dir, &XLINE_TABLES)?;
-    restore_rocks_engine.apply_snapshot(SnapshotProxy::Rocks(rocks_snapshot), &XLINE_TABLES)?;
-    tokio::fs::remove_dir_all(tmp_path).await?;
+    restore_rocks_engine
+        .apply_snapshot(SnapshotProxy::Rocks(rocks_snapshot), &XLINE_TABLES)
+        .await?;
     Ok(())
 }

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -291,7 +291,7 @@ where
         } else {
             None
         };
-        self.persistent.reset(s)
+        self.persistent.reset(s).await
     }
 
     async fn snapshot(&self) -> Result<SnapshotProxy, Self::Error> {

--- a/xline/src/storage/mod.rs
+++ b/xline/src/storage/mod.rs
@@ -14,6 +14,8 @@ pub(crate) mod kvwatcher;
 pub(crate) mod lease_store;
 /// Revision module
 pub(crate) mod revision;
+/// Snapshot Allocators
+pub(crate) mod snapshot_allocator;
 /// Persistent storage abstraction
 pub(crate) mod storage_api;
 

--- a/xline/src/storage/snapshot_allocator.rs
+++ b/xline/src/storage/snapshot_allocator.rs
@@ -1,0 +1,29 @@
+// TODO: add memory snapshot allocator
+use std::error::Error;
+
+use async_trait::async_trait;
+use curp::SnapshotAllocator;
+use engine::snapshot_api::{MemorySnapshot, SnapshotProxy};
+
+/// Rocks snapshot allocator
+pub(crate) struct RocksSnapshotAllocator;
+
+#[async_trait]
+impl SnapshotAllocator for RocksSnapshotAllocator {
+    #[allow(clippy::todo)]
+    async fn allocate_new_snapshot(&self) -> Result<SnapshotProxy, Box<dyn Error>> {
+        // TODO: create real rocks db snapshot
+        todo!()
+    }
+}
+
+/// Memory snapshot allocator
+pub(crate) struct MemorySnapshotAllocator;
+
+#[async_trait]
+impl SnapshotAllocator for MemorySnapshotAllocator {
+    #[allow(clippy::todo)]
+    async fn allocate_new_snapshot(&self) -> Result<SnapshotProxy, Box<dyn Error>> {
+        Ok(SnapshotProxy::Memory(MemorySnapshot::default()))
+    }
+}

--- a/xline/src/storage/snapshot_allocator.rs
+++ b/xline/src/storage/snapshot_allocator.rs
@@ -1,19 +1,19 @@
-// TODO: add memory snapshot allocator
 use std::error::Error;
 
 use async_trait::async_trait;
 use curp::SnapshotAllocator;
-use engine::snapshot_api::{MemorySnapshot, SnapshotProxy};
+use engine::snapshot_api::{MemorySnapshot, RocksSnapshot, SnapshotProxy};
 
 /// Rocks snapshot allocator
 pub(crate) struct RocksSnapshotAllocator;
 
 #[async_trait]
 impl SnapshotAllocator for RocksSnapshotAllocator {
-    #[allow(clippy::todo)]
     async fn allocate_new_snapshot(&self) -> Result<SnapshotProxy, Box<dyn Error>> {
-        // TODO: create real rocks db snapshot
-        todo!()
+        let tmp_path = format!("/tmp/snapshot-{}", uuid::Uuid::new_v4());
+        Ok(SnapshotProxy::Rocks(RocksSnapshot::new_for_receiving(
+            tmp_path,
+        )?))
     }
 }
 
@@ -22,7 +22,6 @@ pub(crate) struct MemorySnapshotAllocator;
 
 #[async_trait]
 impl SnapshotAllocator for MemorySnapshotAllocator {
-    #[allow(clippy::todo)]
     async fn allocate_new_snapshot(&self) -> Result<SnapshotProxy, Box<dyn Error>> {
         Ok(SnapshotProxy::Memory(MemorySnapshot::default()))
     }

--- a/xline/src/storage/storage_api.rs
+++ b/xline/src/storage/storage_api.rs
@@ -5,6 +5,7 @@ use engine::snapshot_api::SnapshotProxy;
 use super::{db::WriteOp, ExecuteError};
 
 /// The Stable Storage Api
+#[async_trait::async_trait]
 pub trait StorageApi: Send + Sync + 'static + std::fmt::Debug {
     /// Get values by keys from storage
     ///
@@ -41,7 +42,7 @@ pub trait StorageApi: Send + Sync + 'static + std::fmt::Debug {
     /// # Errors
     ///
     /// if error occurs in storage, return `Err(error)`
-    fn reset(&self, snapshot: Option<SnapshotProxy>) -> Result<(), ExecuteError>;
+    async fn reset(&self, snapshot: Option<SnapshotProxy>) -> Result<(), ExecuteError>;
 
     /// Get the snapshot of the storage
     fn get_snapshot(&self, snap_path: impl AsRef<Path>) -> Result<SnapshotProxy, ExecuteError>;

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -87,6 +87,7 @@ impl Cluster {
                     },
                     ClientTimeout::default(),
                     default_range_retry_timeout(),
+                    StorageConfig::Memory,
                     db,
                 )
                 .await;


### PR DESCRIPTION
Based on #186, #217 

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

This PR adds log compaction for curp. I.e., we will only reserve a certain number of logs in memory. And if a follower requests for logs that have been compacted, the leader will take a snapshot and send it to the follower.

P.S. I've added a `SnapshotAllocator` API for Xline to implement. Current implementation is insufficient and not tested.
P.S.2 I've renamed our `last_applied` to `last_as` and added a new field `last_exe` because of our two-stage cmd process that is different from the one in original raft. `last_exe` helps us to generate the correct snapshot meta.

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)