### PR TITLE
Unified AE entry

### DIFF
--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -226,6 +226,8 @@ impl<C: 'static + Command> RawCurp<C> {
             self.ctx.cmd_tx.send_sp_exe(cmd);
         }
 
+        self.ctx.sync_event.notify(usize::MAX);
+
         (
             info,
             if conflict {

--- a/curp/src/server/raw_curp/state.rs
+++ b/curp/src/server/raw_curp/state.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use madsim::rand::{thread_rng, Rng};
 use tracing::debug;
@@ -86,10 +89,9 @@ impl State {
 
 impl LeaderState {
     /// Create a `LeaderState`
-    pub(super) fn new(
-        next_index: HashMap<ServerId, LogIndex>,
-        match_index: HashMap<ServerId, LogIndex>,
-    ) -> Self {
+    pub(super) fn new(others: &HashSet<ServerId>) -> Self {
+        let next_index = others.iter().map(|o| (o.clone(), 1)).collect();
+        let match_index = others.iter().map(|o| (o.clone(), 0)).collect();
         Self {
             next_index,
             match_index,

--- a/xline/tests/kv_test.rs
+++ b/xline/tests/kv_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use std::error::Error;
+use std::{error::Error, time::Duration};
 
 use etcd_client::Client;
 use xline::client::kv_types::{
@@ -167,6 +167,7 @@ async fn test_range_redirect() -> Result<(), Box<dyn Error>> {
     let addr = cluster.addrs()["server1"].clone();
     let mut kv_client = Client::connect([addr], None).await?.kv_client();
     let _ignore = kv_client.put("foo", "bar", None).await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
     let res = kv_client.get("foo", None).await?;
     assert_eq!(res.kvs().len(), 1);
     assert_eq!(res.kvs()[0].value(), b"bar");


### PR DESCRIPTION
As described in #223, this PR unify all AE generation functions to one, which will generate ae according to next_index only. And now, one sync task corresponds to one follower now.

Based on #217.