### PR TITLE
fix: clear curp tmp directory after test

### DIFF
--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -224,11 +224,24 @@ impl CurpGroup {
     }
 
     pub fn stop(mut self) {
+        let paths = self
+            .nodes
+            .values()
+            .map(|node| node.storage_path.clone())
+            .chain(
+                self.crashed_nodes
+                    .values()
+                    .map(|node| node.storage_path.clone()),
+            )
+            .collect_vec();
         thread::spawn(move || {
             self.nodes.clear();
         })
         .join()
         .unwrap();
+        for path in paths {
+            std::fs::remove_dir_all(path).unwrap();
+        }
     }
 
     pub fn crash(&mut self, id: &ServerId) {


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
After running the test, many useless directories will be left under the tmp directory
* what changes does this pull request make?
clear curp tmp directory after test
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no