### PR TITLE
refactor kv range request

### DIFF
--- a/curp/proto/message.proto
+++ b/curp/proto/message.proto
@@ -85,6 +85,21 @@ message InstallSnapshotResponse {
     uint64 term = 1;
 }
 
+message IdSet {
+    repeated bytes ids = 1;
+}
+
+message FetchReadStateRequest{
+    bytes command = 1;
+}
+
+message FetchReadStateResponse {
+    oneof read_state {
+        IdSet ids = 1;
+        uint64 commit_index = 2;
+    }
+}
+
 service Protocol {
     rpc Propose (ProposeRequest) returns (ProposeResponse);
     rpc WaitSynced (WaitSyncedRequest) returns (WaitSyncedResponse);
@@ -92,4 +107,5 @@ service Protocol {
     rpc Vote (VoteRequest) returns (VoteResponse);
     rpc FetchLeader (FetchLeaderRequest) returns (FetchLeaderResponse);
     rpc InstallSnapshot (stream InstallSnapshotRequest) returns (InstallSnapshotResponse);
+    rpc FetchReadState (FetchReadStateRequest) returns (FetchReadStateResponse);
 }

--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -46,11 +46,16 @@ pub trait Command:
 
     /// Execute the command after_sync callback
     #[inline]
-    async fn after_sync<E>(&self, e: &E, index: LogIndex) -> Result<Self::ASR, E::Error>
+    async fn after_sync<E>(
+        &self,
+        e: &E,
+        index: LogIndex,
+        need_run: bool,
+    ) -> Result<Self::ASR, E::Error>
     where
         E: CommandExecutor<Self> + Send + Sync,
     {
-        <E as CommandExecutor<Self>>::after_sync(e, self, index).await
+        <E as CommandExecutor<Self>>::after_sync(e, self, index, need_run).await
     }
 }
 
@@ -113,7 +118,12 @@ where
     async fn execute(&self, cmd: &C) -> Result<C::ER, Self::Error>;
 
     /// Execute the after_sync callback
-    async fn after_sync(&self, cmd: &C, index: LogIndex) -> Result<C::ASR, Self::Error>;
+    async fn after_sync(
+        &self,
+        cmd: &C,
+        index: LogIndex,
+        need_run: bool,
+    ) -> Result<C::ASR, Self::Error>;
 
     /// Index of the last log entry that has been successfully applied to the command executor
     fn last_applied(&self) -> Result<LogIndex, Self::Error>;

--- a/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
+++ b/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
@@ -306,7 +306,7 @@ impl<C: Command> Filter<C> {
                     }
                     false
                 }
-                (ExeState::Executed(true), AsState::AfterSyncReady(index)) => {
+                (ExeState::Executed(_), AsState::AfterSyncReady(index)) => {
                     *as_st = AsState::AfterSyncing;
                     let task = Task {
                         vid,
@@ -317,8 +317,7 @@ impl<C: Command> Filter<C> {
                     }
                     false
                 }
-                (ExeState::Executed(true), AsState::AfterSynced)
-                | (ExeState::Executed(false), AsState::AfterSyncReady(_)) => true,
+                (ExeState::Executed(_), AsState::AfterSynced) => true,
                 (ExeState::Executing | ExeState::Executed(_), AsState::NotSynced)
                 | (ExeState::Executing, AsState::AfterSyncReady(_) | AsState::AfterSyncing)
                 | (ExeState::Executed(true), AsState::AfterSyncing) => false,

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -74,13 +74,20 @@ async fn cmd_worker<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
                 cb.write().insert_er(cmd.id(), er);
                 er_ok
             }
-            TaskType::AS(cmd, index) => {
+            TaskType::AS(ref cmd, index) => {
+                let need_run = cb
+                    .read()
+                    .er_buffer
+                    .get(cmd.id())
+                    .map_or(false, Result::is_ok);
                 let asr = ce
-                    .after_sync(cmd.as_ref(), index)
+                    .after_sync(cmd.as_ref(), index, need_run)
                     .await
                     .map_err(|e| e.to_string());
                 let asr_ok = asr.is_ok();
-                cb.write().insert_asr(cmd.id(), asr);
+                if need_run {
+                    cb.write().insert_asr(cmd.id(), asr);
+                }
                 sp.lock().remove(cmd.id());
                 let _ig = ucp.lock().remove(cmd.id());
                 debug!("{id} cmd({}) after sync is called", cmd.id());

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -28,8 +28,9 @@ use crate::{
     log_entry::LogEntry,
     rpc::{
         self, connect::ConnectApi, AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest,
-        FetchLeaderResponse, InstallSnapshotRequest, InstallSnapshotResponse, ProposeRequest,
-        ProposeResponse, VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
+        FetchLeaderResponse, FetchReadStateRequest, FetchReadStateResponse, InstallSnapshotRequest,
+        InstallSnapshotResponse, ProposeRequest, ProposeResponse, VoteRequest, VoteResponse,
+        WaitSyncedRequest, WaitSyncedResponse,
     },
     server::{cmd_worker::CEEventTxApi, raw_curp::SyncAction, storage::rocksdb::RocksDBStorage},
     snapshot::{Snapshot, SnapshotMeta},
@@ -250,6 +251,17 @@ impl<C: 'static + Command> CurpNode<C> {
         Err(CurpError::Transport(
             "failed to receive a complete snapshot".to_owned(),
         ))
+    }
+
+    /// Handle fetch read state requests
+    #[allow(clippy::needless_pass_by_value)] // To keep type consistent with other request handlers
+    pub(super) fn fetch_read_state(
+        &self,
+        req: FetchReadStateRequest,
+    ) -> Result<FetchReadStateResponse, CurpError> {
+        let cmd = req.cmd()?;
+        let state = self.curp.handle_fetch_read_state(&cmd)?;
+        Ok(FetchReadStateResponse::new(state))
     }
 }
 

--- a/curp/src/server/mod.rs
+++ b/curp/src/server/mod.rs
@@ -13,8 +13,9 @@ use crate::{
     error::ServerError,
     rpc::{
         AppendEntriesRequest, AppendEntriesResponse, FetchLeaderRequest, FetchLeaderResponse,
-        InstallSnapshotRequest, InstallSnapshotResponse, ProposeRequest, ProposeResponse,
-        ProtocolServer, VoteRequest, VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
+        FetchReadStateRequest, FetchReadStateResponse, InstallSnapshotRequest,
+        InstallSnapshotResponse, ProposeRequest, ProposeResponse, ProtocolServer, VoteRequest,
+        VoteResponse, WaitSyncedRequest, WaitSyncedResponse,
     },
     ServerId, TxFilter,
 };
@@ -115,6 +116,16 @@ impl<C: 'static + Command> crate::rpc::Protocol for Rpc<C> {
             .map_err(|e| format!("snapshot transmission failed at client side, {e}"));
         Ok(tonic::Response::new(
             self.inner.install_snapshot(req_stream).await?,
+        ))
+    }
+
+    #[instrument(skip_all, name = "curp_fetch_read_state")]
+    async fn fetch_read_state(
+        &self,
+        request: tonic::Request<FetchReadStateRequest>,
+    ) -> Result<tonic::Response<FetchReadStateResponse>, tonic::Status> {
+        Ok(tonic::Response::new(
+            self.inner.fetch_read_state(request.into_inner())?,
         ))
     }
 }

--- a/curp/src/test_utils/test_cmd.rs
+++ b/curp/src/test_utils/test_cmd.rs
@@ -185,6 +185,7 @@ impl CommandExecutor<TestCommand> for TestCE {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
+        need_run: bool,
     ) -> Result<LogIndex, ExecuteError> {
         sleep(cmd.as_dur).await;
         if cmd.as_should_fail {
@@ -192,10 +193,11 @@ impl CommandExecutor<TestCommand> for TestCE {
         }
         self.last_applied
             .store(index.numeric_cast(), Ordering::Relaxed);
-
-        self.after_sync_sender
-            .send((cmd.clone(), index))
-            .expect("failed to send after sync msg");
+        if need_run {
+            self.after_sync_sender
+                .send((cmd.clone(), index))
+                .expect("failed to send after sync msg");
+        }
         Ok(index)
     }
 
@@ -287,6 +289,7 @@ impl CommandExecutor<TestCommand> for TestCESimple {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
+        _need_run: bool,
     ) -> Result<LogIndex, ExecuteError> {
         sleep(cmd.as_dur).await;
         if cmd.as_should_fail {

--- a/curp/tests/common/test_cmd.rs
+++ b/curp/tests/common/test_cmd.rs
@@ -178,15 +178,17 @@ impl CommandExecutor<TestCommand> for TestCE {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
+        need_run: bool,
     ) -> Result<LogIndex, ExecuteError> {
         sleep(cmd.as_dur).await;
         if cmd.as_should_fail {
             return Err(ExecuteError("fail".to_owned()));
         }
-
-        self.after_sync_sender
-            .send((cmd.clone(), index))
-            .expect("failed to send after sync msg");
+        if need_run {
+            self.after_sync_sender
+                .send((cmd.clone(), index))
+                .expect("failed to send after sync msg");
+        }
         self.last_applied.store(index, Ordering::Relaxed);
         Ok(index)
     }

--- a/curp/tests/read_state.rs
+++ b/curp/tests/read_state.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+use curp::{client::ReadState, cmd::Command};
+use utils::config::ClientTimeout;
+
+use crate::common::{curp_group::CurpGroup, init_logger, sleep_millis, test_cmd::TestCommand};
+
+mod common;
+
+#[tokio::test]
+async fn read_state() {
+    init_logger();
+    let group = CurpGroup::new(3).await;
+    let put_client = group.new_client(ClientTimeout::default()).await;
+    let put_cmd = TestCommand::new_put(vec![0], 0).set_exe_dur(Duration::from_millis(100));
+    let put_id = put_cmd.id().clone();
+    tokio::spawn(async move {
+        assert_eq!(put_client.propose(put_cmd).await.unwrap(), vec![]);
+    });
+    let get_client = group.new_client(ClientTimeout::default()).await;
+    let res = get_client
+        .fetch_read_state(&TestCommand::new_get(vec![0]))
+        .await
+        .unwrap();
+    if let ReadState::Ids(v) = res {
+        assert_eq!(v, vec![put_id])
+    } else {
+        unreachable!(
+            "expected result should be ReadState::Ids({:?}), but received {:?}",
+            vec![put_id],
+            res
+        );
+    }
+
+    sleep_millis(100).await;
+
+    let res = get_client
+        .fetch_read_state(&TestCommand::new_get(vec![0]))
+        .await
+        .unwrap();
+    if let ReadState::CommitIndex(index) = res {
+        assert_eq!(index, 1);
+    } else {
+        unreachable!(
+            "expected result should be ReadState::CommitIndex({:?}), but received {:?}",
+            1, res
+        );
+    }
+    group.stop();
+}

--- a/engine/src/rocksdb_engine.rs
+++ b/engine/src/rocksdb_engine.rs
@@ -688,10 +688,11 @@ mod test {
 
     #[tokio::test]
     async fn snapshot_should_work() {
-        let origin_data_dir = PathBuf::from("/tmp/snapshot_should_work_origin");
-        let recover_data_dir = PathBuf::from("/tmp/snapshot_should_work_recover");
-        let snapshot_dir = PathBuf::from("/tmp/snapshot");
-        let snapshot_bak_dir = PathBuf::from("/tmp/snapshot_bak");
+        let test_dir = PathBuf::from("/tmp/snapshot_should_work_rocksdb");
+        let origin_data_dir = test_dir.join("origin");
+        let recover_data_dir = test_dir.join("recover");
+        let snapshot_dir = test_dir.join("snapshot");
+        let snapshot_bak_dir = test_dir.join("snapshot_bak");
 
         let engine = RocksEngine::new(&origin_data_dir, &TESTTABLES).unwrap();
         let put = WriteOperation::new_put("kv", "key".into(), "value".into());
@@ -723,6 +724,6 @@ mod test {
         drop(engine_2);
         destroy(&origin_data_dir);
         destroy(&recover_data_dir);
-        fs::remove_dir_all(&snapshot_dir).unwrap();
+        fs::remove_dir_all(&test_dir).unwrap();
     }
 }

--- a/xline/src/rpc/mod.rs
+++ b/xline/src/rpc/mod.rs
@@ -40,7 +40,6 @@ pub(crate) use self::{
     etcdserverpb::{
         auth_server::{Auth, AuthServer},
         compare::{CompareResult, CompareTarget, TargetUnion},
-        kv_client::KvClient,
         kv_server::{Kv, KvServer},
         lease_client::LeaseClient,
         lease_server::{Lease, LeaseServer},

--- a/xline/src/server/barriers.rs
+++ b/xline/src/server/barriers.rs
@@ -1,0 +1,145 @@
+use std::collections::{BTreeMap, HashMap};
+
+use clippy_utilities::OverflowArithmetic;
+use curp::cmd::ProposeId;
+use event_listener::Event;
+use parking_lot::Mutex;
+
+/// Waiter for index
+#[derive(Debug)]
+pub(crate) struct IndexBarrier {
+    /// Inner
+    inner: Mutex<IndexWaiterInner>,
+}
+
+impl IndexBarrier {
+    /// Create a new index waiter
+    pub(crate) fn new() -> Self {
+        IndexBarrier {
+            inner: Mutex::new(IndexWaiterInner {
+                last_trigger_index: 0,
+                waiters: BTreeMap::new(),
+            }),
+        }
+    }
+
+    /// Wait for the index until it is triggered.
+    pub(crate) async fn wait(&self, index: u64) {
+        let listener = {
+            let mut inner_l = self.inner.lock();
+            if inner_l.last_trigger_index >= index {
+                return;
+            }
+            inner_l
+                .waiters
+                .entry(index)
+                .or_insert_with(Event::new)
+                .listen()
+        };
+        listener.await;
+    }
+
+    /// Trigger all waiters whose index is less than or equal to the given index.
+    pub(crate) fn trigger(&self, index: u64) {
+        let mut inner_l = self.inner.lock();
+        inner_l.last_trigger_index = index;
+        let mut split_waiters = inner_l.waiters.split_off(&(index.overflow_add(1)));
+        std::mem::swap(&mut inner_l.waiters, &mut split_waiters);
+        for (_, waiter) in split_waiters {
+            waiter.notify(usize::MAX);
+        }
+    }
+}
+
+/// Inner of index waiter.
+#[derive(Debug)]
+struct IndexWaiterInner {
+    /// The last index that the waiter has triggered.
+    last_trigger_index: u64,
+    /// Waiters of index.
+    waiters: BTreeMap<u64, Event>,
+}
+
+/// Waiter for id
+#[derive(Debug)]
+pub(crate) struct IdBarrier {
+    /// Waiters of id
+    waiters: Mutex<HashMap<ProposeId, Event>>,
+}
+
+impl IdBarrier {
+    /// Create a new id waiter
+    pub(crate) fn new() -> Self {
+        Self {
+            waiters: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Wait for the id until it is triggered.
+    pub(crate) async fn wait(&self, id: ProposeId) {
+        let listener = self
+            .waiters
+            .lock()
+            .entry(id)
+            .or_insert_with(Event::new)
+            .listen();
+        listener.await;
+    }
+
+    /// Trigger the waiter of the given id.
+    pub(crate) fn trigger(&self, id: &ProposeId) {
+        if let Some(event) = self.waiters.lock().remove(id) {
+            event.notify(usize::MAX);
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::{sync::Arc, time::Duration};
+
+    use futures::future::join_all;
+    use tokio::time::{sleep, timeout};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_id_waiter() {
+        let id_waiter = Arc::new(IdBarrier::new());
+        let waiters = (0..5)
+            .map(|i| {
+                let id_waiter = Arc::clone(&id_waiter);
+                tokio::spawn(async move {
+                    id_waiter.wait(ProposeId::new(i.to_string())).await;
+                })
+            })
+            .collect::<Vec<_>>();
+        sleep(Duration::from_millis(10)).await;
+        for i in 0..5 {
+            id_waiter.trigger(&ProposeId::new(i.to_string()));
+        }
+        timeout(Duration::from_millis(100), join_all(waiters))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_index_waiter() {
+        let index_waiter = Arc::new(IndexBarrier::new());
+        let waiters = (0..5).map(|i| {
+            let id_waiter = Arc::clone(&index_waiter);
+            tokio::spawn(async move {
+                id_waiter.wait(i).await;
+            })
+        });
+        index_waiter.trigger(5);
+
+        timeout(Duration::from_millis(100), index_waiter.wait(3))
+            .await
+            .unwrap();
+
+        timeout(Duration::from_millis(100), join_all(waiters))
+            .await
+            .unwrap();
+    }
+}

--- a/xline/src/server/mod.rs
+++ b/xline/src/server/mod.rs
@@ -1,5 +1,7 @@
 /// Xline auth server
 mod auth_server;
+/// Barriers for range requests
+mod barriers;
 /// Command to be executed
 pub(crate) mod command;
 /// Xline kv server

--- a/xline/src/storage/db.rs
+++ b/xline/src/storage/db.rs
@@ -312,7 +312,7 @@ mod test {
     #[test]
     fn test_reset() -> Result<(), ExecuteError> {
         let data_dir = PathBuf::from("/tmp/test_reset");
-        let db = DBProxy::open(&StorageConfig::RocksDB(data_dir))?;
+        let db = DBProxy::open(&StorageConfig::RocksDB(data_dir.clone()))?;
 
         let revision = Revision::new(1, 1);
         let key = revision.encode_to_vec();
@@ -328,6 +328,7 @@ mod test {
         let res = db.get_all(KV_TABLE)?;
         assert!(res.is_empty());
 
+        std::fs::remove_dir_all(data_dir).unwrap();
         Ok(())
     }
 

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -7,7 +7,7 @@ use tokio::{
     sync::broadcast::{self, Sender},
     time::{self, Duration},
 };
-use utils::config::{ClientTimeout, CurpConfig, StorageConfig};
+use utils::config::{default_range_retry_timeout, ClientTimeout, CurpConfig, StorageConfig};
 use xline::{client::Client, server::XlineServer, storage::db::DBProxy};
 
 /// Cluster
@@ -73,6 +73,7 @@ impl Cluster {
                         ..Default::default()
                     },
                     ClientTimeout::default(),
+                    default_range_retry_timeout(),
                     db,
                 )
                 .await;


### PR DESCRIPTION

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
fix wrong range processing
* what changes does this pull request make?
when follower receives range request, it will send fetch read state request to leader, leader will return a group of propose id or commit index, follower will wait these id or index applied, then it can safely read from its own state machine and return.
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no