### PR TITLE
recover persistent storage from snapshot file

### DIFF
--- a/xline/src/bin/restore_client.rs
+++ b/xline/src/bin/restore_client.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+use clap::Parser;
+use xline::client::restore::restore;
+
+#[derive(Parser, Debug)]
+struct ClientArgs {
+    snapshot_path: PathBuf,
+    #[clap(short, long)]
+    data_dir: PathBuf,
+}
+
+#[tokio::main]
+async fn main() {
+    let args: ClientArgs = ClientArgs::parse();
+    if let Err(e) = restore(args.snapshot_path, args.data_dir).await {
+        eprintln!("Error: {:?}", e);
+    }
+}

--- a/xline/src/client/errors.rs
+++ b/xline/src/client/errors.rs
@@ -10,6 +10,12 @@ pub enum ClientError {
     /// Propose error
     #[error("propose error {0}")]
     ProposeError(#[from] curp::error::ProposeError),
+    /// IO error
+    #[error("IO error {0}")]
+    IoError(#[from] std::io::Error),
+    /// Engine error
+    #[error("Engine error {0}")]
+    EngineError(#[from] engine::error::EngineError),
 }
 
 impl From<etcd_client::Error> for ClientError {

--- a/xline/src/client/mod.rs
+++ b/xline/src/client/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fmt::Debug};
 use curp::{client::Client as CurpClient, cmd::ProposeId};
 use etcd_client::{
     AuthClient, Client as EtcdClient, KvClient, LeaseClient, LeaseKeepAliveStream, LeaseKeeper,
-    LockClient, WatchClient,
+    LockClient, MaintenanceClient, WatchClient,
 };
 use itertools::Itertools;
 use utils::config::ClientTimeout;
@@ -30,6 +30,8 @@ mod convert;
 pub mod errors;
 /// Requests used by Client
 pub mod kv_types;
+/// Restore from snapshot
+pub mod restore;
 
 /// Xline client
 pub struct Client {
@@ -263,5 +265,11 @@ impl Client {
     #[inline]
     pub fn lease_client(&self) -> LeaseClient {
         self.etcd_client.lease_client()
+    }
+
+    /// Gets a maintenance client.
+    #[inline]
+    pub fn maintenance_client(&self) -> MaintenanceClient {
+        self.etcd_client.maintenance_client()
     }
 }

--- a/xline/src/client/restore.rs
+++ b/xline/src/client/restore.rs
@@ -1,0 +1,40 @@
+use std::path::Path;
+
+use clippy_utilities::Cast;
+use engine::{
+    engine_api::SnapshotApi,
+    rocksdb_engine::{RocksEngine, RocksSnapshot},
+    StorageEngine,
+};
+use tokio::io::AsyncReadExt;
+
+use crate::{
+    client::errors::ClientError, server::MAINTENANCE_SNAPSHOT_CHUNK_SIZE, storage::db::XLINE_TABLES,
+};
+
+/// Restore snapshot to data dir
+/// # Errors
+/// return `ClientError::IoError` if meet io errors
+/// return `ClientError::EngineError` if meet engine errors
+#[inline]
+#[allow(clippy::indexing_slicing)] // safe operation
+pub async fn restore(
+    snapshot_path: impl AsRef<Path>,
+    data_dir: impl AsRef<Path>,
+) -> Result<(), ClientError> {
+    let mut snapshot_f = tokio::fs::File::open(snapshot_path).await?;
+    let tmp_path = format!("/tmp/snapshot-{}", uuid::Uuid::new_v4());
+    let mut rocks_snapshot = RocksSnapshot::new_for_receiving(tmp_path.clone())?;
+    let mut buf = vec![0; MAINTENANCE_SNAPSHOT_CHUNK_SIZE.cast()];
+    while let Ok(n) = snapshot_f.read(&mut buf).await {
+        if n == 0 {
+            break;
+        }
+        rocks_snapshot.write_all(&buf[..n]).await?;
+    }
+
+    let restore_rocks_engine = RocksEngine::new(data_dir, &XLINE_TABLES)?;
+    restore_rocks_engine.apply_snapshot(rocks_snapshot, &XLINE_TABLES)?;
+    tokio::fs::remove_dir_all(tmp_path).await?;
+    Ok(())
+}

--- a/xline/src/server/maintenance.rs
+++ b/xline/src/server/maintenance.rs
@@ -20,7 +20,7 @@ use crate::{
 /// Minimum page size
 const MIN_PAGE_SIZE: u64 = 512;
 /// Snapshot chunk size
-const MAINTENANCE_SNAPSHOT_CHUNK_SIZE: u64 = 64 * 1024;
+pub(crate) const MAINTENANCE_SNAPSHOT_CHUNK_SIZE: u64 = 64 * 1024;
 
 /// Maintenance Server
 #[derive(Debug)]
@@ -224,6 +224,7 @@ mod test {
         let snap1_data = recv_data[..size].to_vec();
         assert_eq!(snap1_data, snap2_data);
 
+        snap2.clean().await.unwrap();
         std::fs::remove_dir_all(dir).unwrap();
         Ok(())
     }

--- a/xline/src/server/mod.rs
+++ b/xline/src/server/mod.rs
@@ -15,4 +15,5 @@ mod watch_server;
 /// Xline server
 mod xline_server;
 
+pub(crate) use self::maintenance::MAINTENANCE_SNAPSHOT_CHUNK_SIZE;
 pub use self::xline_server::XlineServer;

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -222,6 +222,10 @@ where
     where
         F: Future<Output = ()>,
     {
+        // lease storage must recover before kv storage
+        self.lease_storage.recover()?;
+        self.kv_storage.recover().await?;
+        self.auth_storage.recover()?;
         let (
             kv_server,
             lock_server,

--- a/xline/src/storage/db.rs
+++ b/xline/src/storage/db.rs
@@ -22,7 +22,7 @@ use crate::{
 };
 
 /// Xline Server Storage Table
-const XLINE_TABLES: [&str; 6] = [
+pub(crate) const XLINE_TABLES: [&str; 6] = [
     META_TABLE,
     KV_TABLE,
     LEASE_TABLE,
@@ -312,7 +312,7 @@ mod test {
     #[test]
     fn test_reset() -> Result<(), ExecuteError> {
         let data_dir = PathBuf::from("/tmp/test_reset");
-        let db = DBProxy::open(&StorageConfig::RocksDB(data_dir))?;
+        let db = DBProxy::open(&StorageConfig::RocksDB(data_dir.clone()))?;
 
         let revision = Revision::new(1, 1);
         let key = revision.encode_to_vec();
@@ -328,15 +328,17 @@ mod test {
         let res = db.get_all(KV_TABLE)?;
         assert!(res.is_empty());
 
+        std::fs::remove_dir_all(data_dir).unwrap();
         Ok(())
     }
 
-    #[test]
-    fn test_get_snapshot() -> Result<(), ExecuteError> {
+    #[tokio::test]
+    async fn test_get_snapshot() -> Result<(), ExecuteError> {
         let data_dir = PathBuf::from("/tmp/test_get_snapshot");
         let db = DBProxy::open(&StorageConfig::RocksDB(data_dir.clone()))?;
-        let res = db.get_snapshot()?;
+        let mut res = db.get_snapshot()?;
         assert_ne!(res.size(), 0);
+        res.clean().await.unwrap();
         std::fs::remove_dir_all(data_dir).unwrap();
         Ok(())
     }

--- a/xline/tests/maintenance.rs
+++ b/xline/tests/maintenance.rs
@@ -1,0 +1,44 @@
+use std::{path::PathBuf, time::Duration};
+
+use common::Cluster;
+use tokio::io::AsyncWriteExt;
+use xline::client::{
+    kv_types::{PutRequest, RangeRequest},
+    restore::restore,
+};
+
+mod common;
+
+#[tokio::test]
+async fn test_snapshot_and_restore() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = PathBuf::from("/tmp/test_snapshot_and_restore");
+    tokio::fs::create_dir_all(&dir).await?;
+    let snapshot_path = dir.join("snapshot");
+    let restore_dirs = (0..3).map(|i| dir.join(format!("restore_{}", i))).collect();
+    {
+        let mut cluster = Cluster::new(3).await;
+        cluster.start().await;
+        let client = cluster.client().await;
+        let _ignore = client.put(PutRequest::new("key", "value")).await?;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let mut maintenance_client = client.maintenance_client();
+        let mut stream = maintenance_client.snapshot().await?;
+        let mut snapshot = tokio::fs::File::create(&snapshot_path).await?;
+        while let Some(chunk) = stream.message().await? {
+            snapshot.write_all(chunk.blob()).await?;
+        }
+    }
+    for restore_dir in &restore_dirs {
+        restore(&snapshot_path, &restore_dir).await?;
+    }
+    let mut new_cluster = Cluster::new(3).await;
+    new_cluster.set_paths(restore_dirs);
+    new_cluster.start().await;
+    let client = new_cluster.client().await;
+    let res = client.range(RangeRequest::new("key")).await?;
+    assert_eq!(res.kvs.len(), 1);
+    assert_eq!(res.kvs[0].key, b"key");
+    assert_eq!(res.kvs[0].value, b"value");
+    tokio::fs::remove_dir_all(&dir).await?;
+    Ok(())
+}


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
add recover logic of maintenance snapshot file
* what changes does this pull request make?
implement a tmp client to restore, will be merge in our own client in the future
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no