### PR TITLE
Refactor: improve install_snapshot_stream generation logic

### DIFF
--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -284,37 +284,7 @@ fn install_snapshot_stream(
     leader_id: ServerId,
     snapshot: Snapshot,
 ) -> impl Stream<Item = InstallSnapshotRequest> {
-    // FIXME: The following code is better. But it will result in an unknown compiling error that might origin from a compiler bug(https://github.com/rust-lang/rust/issues/102211).
-    // let req_stream = futures::stream::unfold(
-    //     (0, snapshot, term, leader_id, meta),
-    //     |(offset, mut snapshot, term, leader_id, meta)| async move {
-    //         if offset >= snapshot.size() {
-    //             return None;
-    //         }
-    //         let mut data = Vec::with_capacity(
-    //             std::cmp::min(snapshot.size() - offset, SNAPSHOT_CHUNK_SIZE).numeric_cast(),
-    //         );
-    //         let n: u64 = match snapshot.read(&mut data) {
-    //             Ok(n) => n.numeric_cast(),
-    //             Err(e) => {
-    //                 error!("read snapshot error, {e}");
-    //                 return None;
-    //             }
-    //         };
-    //         let done = (offset + n) == snapshot.size();
-    //         let req = InstallSnapshotRequest {
-    //             term,
-    //             leader_id: leader_id.clone(),
-    //             last_included_index: meta.last_included_index,
-    //             last_included_term: meta.last_included_term,
-    //             offset,
-    //             data,
-    //             done,
-    //         };
-    //         Some((req, (offset + n, snapshot, term, leader_id, meta)))
-    //     },
-    // );
-
+    // FIXME: Maybe here is unnecessary to spawn a new task to generate the stream
     let (tx, rx) = mpsc::channel(1);
     let _ig = tokio::spawn(async move {
         let meta = snapshot.meta;

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -19,12 +19,12 @@ use super::{
     cmd_board::{CmdBoardRef, CommandBoard},
     cmd_worker::{conflict_checked_mpmc, start_bg_workers, CEEventTx},
     gc::run_gc_tasks,
-    raw_curp::{AppendEntries, RawCurp, Vote},
+    raw_curp::{AppendEntries, RawCurp, UncommittedPool, Vote},
     spec_pool::{SpecPoolRef, SpeculativePool},
     storage::{StorageApi, StorageError},
 };
 use crate::{
-    cmd::{Command, CommandExecutor, ProposeId},
+    cmd::{Command, CommandExecutor},
     error::ProposeError,
     log_entry::LogEntry,
     rpc::{
@@ -37,12 +37,6 @@ use crate::{
     snapshot::{Snapshot, SnapshotMeta},
     ServerId, TxFilter,
 };
-
-/// Uncommitted pool type
-pub(super) type UncommittedPool<C> = HashMap<ProposeId, Arc<C>>;
-
-/// Reference to uncommitted pool
-pub(super) type UncommittedPoolRef<C> = Arc<Mutex<UncommittedPool<C>>>;
 
 /// Curp error
 #[derive(Debug, Error)]

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -523,7 +523,7 @@ impl<C: 'static + Command> RawCurp<C> {
     }
 
     /// Handle `install_snapshot` resp
-    /// Return Err(()) if
+    /// Return Err(()) if the current node isn't a leader or current term is less than the given term
     pub(super) fn handle_snapshot_resp(
         &self,
         follower_id: &ServerId,

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -897,8 +897,8 @@ impl<C: 'static + Command> RawCurp<C> {
         let existing_log_ids = log.get_cmd_ids();
         let recovered_cmds = cmd_cnt
             .into_values()
-            // only cmds whose cnt >= 3/4 can be recovered
-            .filter_map(|(cmd, cnt)| (cnt >= self.superquorum()).then_some(cmd))
+            // only cmds whose cnt >= ( f + 1 ) / 2 + 1 can be recovered
+            .filter_map(|(cmd, cnt)| (cnt >= self.recover_quorum()).then_some(cmd))
             // dedup in current logs
             .filter(|cmd| {
                 // TODO: better dedup mechanism
@@ -951,8 +951,8 @@ impl<C: 'static + Command> RawCurp<C> {
         (self.ctx.others.len() / 2 + 1).numeric_cast()
     }
 
-    /// Get superquorum: the smallest number of servers who must contain a command in speculative pool for it to be recovered
-    fn superquorum(&self) -> u64 {
+    /// Get `recover_quorum`: the smallest number of servers who must contain a command in speculative pool for it to be recovered
+    fn recover_quorum(&self) -> u64 {
         self.quorum() / 2 + 1
     }
 

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -37,7 +37,7 @@ use self::{
     log::Log,
     state::{CandidateState, LeaderState, State},
 };
-use super::{cmd_worker::CEEventTxApi, curp_node::UncommittedPoolRef};
+use super::cmd_worker::CEEventTxApi;
 use crate::{
     cmd::{Command, ProposeId},
     error::ProposeError,
@@ -53,6 +53,12 @@ mod state;
 
 /// Curp log
 mod log;
+
+/// Uncommitted pool type
+pub(super) type UncommittedPool<C> = HashMap<ProposeId, Arc<C>>;
+
+/// Reference to uncommitted pool
+type UncommittedPoolRef<C> = Arc<Mutex<UncommittedPool<C>>>;
 
 /// The curp state machine
 #[derive(Debug)]

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -523,5 +523,5 @@ fn quorum() {
         Arc::new(RawCurp::new_test(5, exe_tx))
     };
     assert_eq!(curp.quorum(), 3);
-    assert_eq!(curp.superquorum(), 2);
+    assert_eq!(curp.recover_quorum(), 2);
 }

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -11,7 +11,7 @@ use crate::{
     server::{
         cmd_board::CommandBoard,
         cmd_worker::{CEEventTxApi, MockCEEventTxApi},
-        curp_node::UncommittedPool,
+        raw_curp::UncommittedPool,
         spec_pool::SpeculativePool,
     },
     test_utils::test_cmd::TestCommand,

--- a/engine/src/memory_engine.rs
+++ b/engine/src/memory_engine.rs
@@ -156,9 +156,8 @@ mod test {
 
     use clippy_utilities::NumericCast;
 
-    use crate::snapshot_api::SnapshotApi;
-
     use super::*;
+    use crate::snapshot_api::SnapshotApi;
 
     const TESTTABLES: [&'static str; 3] = ["kv", "lease", "auth"];
 

--- a/engine/src/rocksdb_engine.rs
+++ b/engine/src/rocksdb_engine.rs
@@ -224,9 +224,8 @@ mod test {
 
     use clippy_utilities::NumericCast;
 
-    use crate::snapshot_api::SnapshotApi;
-
     use super::*;
+    use crate::snapshot_api::SnapshotApi;
     const TESTTABLES: [&'static str; 3] = ["kv", "lease", "auth"];
 
     #[test]

--- a/engine/src/snapshot_api/rocks_snapshot.rs
+++ b/engine/src/snapshot_api/rocks_snapshot.rs
@@ -15,9 +15,8 @@ use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
 };
 
-use crate::error::EngineError;
-
 use super::SnapshotApi;
+use crate::error::EngineError;
 
 /// Human readable format for `RocksEngine`
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -281,7 +281,7 @@ pub const fn default_range_retry_timeout() -> Duration {
 /// default gc interval
 #[must_use]
 #[inline]
-pub fn default_gc_interval() -> Duration {
+pub const fn default_gc_interval() -> Duration {
     Duration::from_secs(20)
 }
 

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -208,7 +208,7 @@ struct ServerArgs {
     /// Curp client retry timeout [default: 50ms]
     #[clap(long, value_parser = parse_duration)]
     client_retry_timeout: Option<Duration>,
-    /// How often should the gc task run
+    /// How often should the gc task run [default: 20s]
     #[clap(long, value_parser = parse_duration)]
     gc_interval: Option<Duration>,
     /// Range request retry timeout [default: 2s]

--- a/xline/src/storage/db.rs
+++ b/xline/src/storage/db.rs
@@ -193,7 +193,7 @@ where
 /// lose some flexibility when calling these methods.
 /// 2. A dyn object should not be bounded by Sized trait, and some async functions, like
 /// `XlineServer::new`, requires its parameter to satisfy the Sized trait when we await
-/// it. So here is a contradictory.
+/// it. So here is a contradiction.
 #[non_exhaustive]
 #[derive(Debug)]
 pub enum DBProxy {


### PR DESCRIPTION
Please briefly answer these questions:
use async_stream::stream! to generate install_snapshot stream, closes #230 

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Viewing #230 for more details.

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No