### PR TITLE
Use `Vec<u8>` as key and value instead of `u32` in tests

### DIFF
--- a/curp/tests/common/curp_group.rs
+++ b/curp/tests/common/curp_group.rs
@@ -82,7 +82,7 @@ pub struct CurpNode {
     pub addr: String,
     pub exe_rx: mpsc::UnboundedReceiver<(TestCommand, TestCommandResult)>,
     pub as_rx: mpsc::UnboundedReceiver<(TestCommand, LogIndex)>,
-    pub store: Arc<Mutex<HashMap<u32, u32>>>,
+    pub store: Arc<Mutex<HashMap<Vec<u8>, Vec<u8>>>>,
     pub rt: Runtime,
     pub switch: Arc<AtomicBool>,
     pub storage_path: String,

--- a/curp/tests/server_recovery.rs
+++ b/curp/tests/server_recovery.rs
@@ -280,7 +280,10 @@ async fn old_leader_will_discard_spec_exe_cmds() {
     sleep_millis(100).await;
     let leader1_store = Arc::clone(&group.get_node(&leader1).store);
     leader1_store.map_lock(|store_l| {
-        assert_eq!(*store_l, HashMap::from_iter([(0, 1)]));
+        assert_eq!(
+            *store_l,
+            HashMap::from_iter([(0u32.to_be_bytes().to_vec(), 1u32.to_be_bytes().to_vec())])
+        );
     });
 
     // 3: recover all others and disable leader, a new leader will be elected
@@ -297,7 +300,10 @@ async fn old_leader_will_discard_spec_exe_cmds() {
     group.enable_node(&leader1);
     sleep_secs(1).await;
     leader1_store.map_lock(|store_l| {
-        assert_eq!(*store_l, HashMap::from_iter([(0, 0)]));
+        assert_eq!(
+            *store_l,
+            HashMap::from_iter([(0u32.to_be_bytes().to_vec(), 0u32.to_be_bytes().to_vec())])
+        );
     });
 
     // 5: the client should also get the original state


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Some pre-work for refactoring the engine, the next PR will use the engine to replace the store, and the engine cannot use u32 as a key
* what changes does this pull request make?
Use `Vec<u8>` as key and value instead of `u32` in Curp tests
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no