### PR TITLE
Refactor/dependencies

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,8 +27,7 @@ jobs:
           args: --release
       - run: |
           cd scripts
-          cp ../target/release/xline .
-          cp ../target/release/benchmark .
+          cp ../target/release/{xline,benchmark} .
           docker build . -t datenlord/xline:latest
           docker pull datenlord/etcd:v3.5.5
           bash ./benchmark.sh

--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -11,10 +11,8 @@ use crate::{
     cmd::{Command, ProposeId},
     error::ProposeError,
     rpc::{
-        self,
-        connect::ConnectApi,
-        FetchLeaderRequest, FetchReadStateRequest, ProposeRequest, ReadState as PbReadState,
-        SyncError, SyncResult, WaitSyncedRequest,
+        self, connect::ConnectApi, FetchLeaderRequest, FetchReadStateRequest, ProposeRequest,
+        ReadState as PbReadState, SyncError, SyncResult, WaitSyncedRequest,
     },
     LogIndex, ServerId,
 };

--- a/curp/src/client.rs
+++ b/curp/src/client.rs
@@ -12,7 +12,7 @@ use crate::{
     error::ProposeError,
     rpc::{
         self,
-        connect::{Connect, ConnectApi},
+        connect::ConnectApi,
         FetchLeaderRequest, FetchReadStateRequest, ProposeRequest, ReadState as PbReadState,
         SyncError, SyncResult, WaitSyncedRequest,
     },
@@ -24,7 +24,7 @@ pub struct Client<C: Command> {
     /// Current leader and term
     state: RwLock<State>,
     /// All servers's `Connect`
-    connects: HashMap<ServerId, Arc<Connect>>,
+    connects: HashMap<ServerId, Arc<dyn ConnectApi>>,
     /// Curp client timeout settings
     timeout: ClientTimeout,
     /// To keep Command type

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -39,7 +39,7 @@ pub trait TxFilter: Send + Sync + Debug {
 pub(crate) async fn connect(
     addrs: HashMap<ServerId, String>,
     tx_filter: Option<Box<dyn TxFilter>>,
-) -> HashMap<ServerId, Arc<Connect>> {
+) -> HashMap<ServerId, Arc<dyn ConnectApi>> {
     futures::future::join_all(addrs.into_iter().map(|(id, mut addr)| async move {
         // Addrs must start with "http" to communicate with the server
         if !addr.starts_with("http://") {
@@ -55,7 +55,7 @@ pub(crate) async fn connect(
     .into_iter()
     .map(|(id, addr, conn)| {
         debug!("successfully establish connection with {addr}");
-        let connect = Arc::new(Connect {
+        let connect: Arc<dyn ConnectApi> = Arc::new(Connect {
             id: id.clone(),
             rpc_connect: RwLock::new(conn),
             addr,

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -57,7 +57,7 @@ impl<C: Command> Debug for CEEvent<C> {
 
 /// Worker that execute commands
 async fn cmd_worker<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
-    cmd_rx: TaskRx<C>,
+    cmd_rx: impl TaskRxApi<C>,
     done_tx: flume::Sender<(Task<C>, bool)>,
     curp: Arc<RawCurp<C>>,
     ce: Arc<CE>,
@@ -129,7 +129,7 @@ async fn cmd_worker<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
 
 /// Worker that execute `after_sync`
 async fn as_worker<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
-    as_task_rx: TaskRx<C>,
+    as_task_rx: impl TaskRxApi<C>,
     done_tx: flume::Sender<(Task<C>, bool)>,
     curp: Arc<RawCurp<C>>,
     ce: Arc<CE>,

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -279,7 +279,7 @@ impl<C: 'static + Command> CurpNode<C> {
     /// Tick periodically
     async fn election_task(
         curp: Arc<RawCurp<C>>,
-        connects: HashMap<ServerId, Arc<impl ConnectApi>>,
+        connects: HashMap<ServerId, Arc<impl ConnectApi + ?Sized>>,
     ) {
         let heartbeat_interval = curp.cfg().heartbeat_interval;
         // wait for some random time before tick starts to minimize vote split possibility
@@ -301,7 +301,7 @@ impl<C: 'static + Command> CurpNode<C> {
     /// Responsible for bringing up `sync_follower_task` when self becomes leader
     async fn sync_follower_daemon(
         curp: Arc<RawCurp<C>>,
-        connect: Arc<impl ConnectApi>,
+        connect: Arc<impl ConnectApi + ?Sized>,
         sync_event: Arc<Event>,
     ) {
         let leader_event = curp.leader_event();
@@ -321,7 +321,7 @@ impl<C: 'static + Command> CurpNode<C> {
     /// Leader use this task to keep a follower up-to-date, will return if self is no longer leader
     async fn sync_follower_task(
         curp: Arc<RawCurp<C>>,
-        connect: Arc<impl ConnectApi>,
+        connect: Arc<impl ConnectApi + ?Sized>,
         sync_event: Arc<Event>,
     ) {
         let mut hb_opt = false;
@@ -527,7 +527,7 @@ impl<C: 'static + Command> CurpNode<C> {
     /// Candidate broadcasts votes
     async fn bcast_vote(
         curp: &RawCurp<C>,
-        connects: &HashMap<ServerId, Arc<impl ConnectApi>>,
+        connects: &HashMap<ServerId, Arc<impl ConnectApi + ?Sized>>,
         vote: Vote,
     ) {
         debug!("{} broadcasts votes to all servers", curp.id());
@@ -583,7 +583,7 @@ impl<C: 'static + Command> CurpNode<C> {
     /// Send `append_entries` request
     #[allow(clippy::integer_arithmetic)] // won't overflow
     async fn send_ae(
-        connect: &impl ConnectApi,
+        connect: &(impl ConnectApi + ?Sized),
         curp: &RawCurp<C>,
         ae: AppendEntries<C>,
     ) -> Result<(), SendAEError> {
@@ -623,7 +623,7 @@ impl<C: 'static + Command> CurpNode<C> {
 
     /// Send snapshot
     async fn send_snapshot(
-        connect: &impl ConnectApi,
+        connect: &(impl ConnectApi + ?Sized),
         curp: &RawCurp<C>,
         snapshot: Snapshot,
     ) -> Result<(), SendSnapshotError> {

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -422,15 +422,15 @@ mod tests {
 
     #[test]
     fn get_from_should_success() {
-        let log_entry = LogEntry::new(0, 0, Arc::new(TestCommand::default()));
-        let log_entry_size = serialized_size(&log_entry).unwrap();
-        // println!("log_entry_size = {log_entry_size}");
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut log =
             Log::<TestCommand>::new(tx, default_batch_max_size(), default_log_entries_cap());
 
+        let _res = log.push_cmd(1, Arc::new(TestCommand::default()));
+        let log_entry_size = log.batch_index[1];
+
         let _res = repeat(TestCommand::default())
-            .take(10)
+            .take(9)
             .map(|cmd| log.push_cmd(1, Arc::new(cmd)).unwrap())
             .collect::<Vec<u64>>();
 
@@ -452,9 +452,10 @@ mod tests {
         assert_eq!(
             bound_2,
             3..7,
-            "batch_index = {:?}, batch = {}",
+            "batch_index = {:?}, batch = {}, log_entry_size = {}",
             log.batch_index,
-            log.batch_limit
+            log.batch_limit,
+            log_entry_size
         );
         assert!(log.has_next_batch(7));
         assert!(!log.has_next_batch(8));
@@ -464,9 +465,10 @@ mod tests {
         assert_eq!(
             bound_3,
             3..8,
-            "batch_index = {:?}, batch = {}",
+            "batch_index = {:?}, batch = {}, log_entry_size = {}",
             log.batch_index,
-            log.batch_limit
+            log.batch_limit,
+            log_entry_size
         );
         assert!(log.has_next_batch(5));
         assert!(!log.has_next_batch(6));
@@ -476,9 +478,10 @@ mod tests {
         assert_eq!(
             bound_4,
             3..10,
-            "batch_index = {:?}, batch = {}",
+            "batch_index = {:?}, batch = {}, log_entry_size = {}",
             log.batch_index,
-            log.batch_limit
+            log.batch_limit,
+            log_entry_size
         );
         assert!(!log.has_next_batch(1));
         assert!(!log.has_next_batch(5));
@@ -488,21 +491,20 @@ mod tests {
         assert_eq!(
             bound_5,
             3..3,
-            "batch_index = {:?}, batch = {}",
+            "batch_index = {:?}, batch = {}, log_entry_size = {}",
             log.batch_index,
-            log.batch_limit
+            log.batch_limit,
+            log_entry_size
         );
         assert!(log.has_next_batch(10));
     }
 
     #[test]
     fn recover_log_should_success() {
-        let entry_size =
-            serialized_size(&LogEntry::new(0, 0, Arc::new(TestCommand::default()))).unwrap();
         let entries = repeat(Arc::new(TestCommand::default()))
             .enumerate()
             .take(10)
-            .map(|(idx, cmd)| LogEntry::new((idx + 1).numeric_cast(), 0, cmd))
+            .map(|(idx, cmd)| LogEntry::new((idx + 1).numeric_cast(), 1, cmd))
             .collect::<Vec<LogEntry<TestCommand>>>();
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut log =
@@ -512,11 +514,18 @@ mod tests {
         assert_eq!(log.entries.len(), 10);
         assert_eq!(log.batch_index.len(), 11);
         assert_eq!(log.batch_index[0], 0);
+        let entry_size = log.batch_index[1];
 
-        log.batch_index
-            .iter()
-            .enumerate()
-            .for_each(|(idx, &size)| assert_eq!(size, entry_size * idx.numeric_cast::<u64>()));
+        log.batch_index.iter().enumerate().for_each(|(idx, &size)| {
+            assert_eq!(
+                size,
+                entry_size * idx.numeric_cast::<u64>(),
+                "batch_index = {:?}, batch = {}, entry_size = {}",
+                log.batch_index,
+                log.batch_limit,
+                entry_size
+            );
+        });
     }
 
     #[test]

--- a/curp/src/server/raw_curp/log.rs
+++ b/curp/src/server/raw_curp/log.rs
@@ -424,7 +424,7 @@ mod tests {
     fn get_from_should_success() {
         let log_entry = LogEntry::new(0, 0, Arc::new(TestCommand::default()));
         let log_entry_size = serialized_size(&log_entry).unwrap();
-
+        // println!("log_entry_size = {log_entry_size}");
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut log =
             Log::<TestCommand>::new(tx, default_batch_max_size(), default_log_entries_cap());
@@ -439,9 +439,10 @@ mod tests {
         assert_eq!(
             bound_1,
             3..5,
-            "batch_index = {:?}, batch = {}",
+            "batch_index = {:?}, batch = {}, log_entry_size = {}",
             log.batch_index,
-            log.batch_limit
+            log.batch_limit,
+            log_entry_size
         );
         assert!(log.has_next_batch(8));
         assert!(!log.has_next_batch(9));

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -142,7 +142,7 @@ struct Context<C: Command> {
     /// Election tick
     election_tick: AtomicU8,
     /// Tx to send cmds to execute and do after sync
-    cmd_tx: Box<dyn CEEventTxApi<C>>,
+    cmd_tx: Arc<dyn CEEventTxApi<C>>,
     /// Followers sync event trigger
     sync_events: HashMap<ServerId, Arc<Event>>,
     /// Become leader event
@@ -577,7 +577,7 @@ impl<C: 'static + Command> RawCurp<C> {
         spec_pool: SpecPoolRef<C>,
         uncommitted_pool: UncommittedPoolRef<C>,
         cfg: Arc<CurpConfig>,
-        cmd_tx: Box<dyn CEEventTxApi<C>>,
+        cmd_tx: Arc<dyn CEEventTxApi<C>>,
         sync_events: HashMap<ServerId, Arc<Event>>,
         log_tx: mpsc::UnboundedSender<LogEntry<C>>,
     ) -> Self {
@@ -625,7 +625,7 @@ impl<C: 'static + Command> RawCurp<C> {
         spec_pool: SpecPoolRef<C>,
         uncommitted_pool: UncommittedPoolRef<C>,
         cfg: &Arc<CurpConfig>,
-        cmd_tx: Box<dyn CEEventTxApi<C>>,
+        cmd_tx: Arc<dyn CEEventTxApi<C>>,
         sync_event: HashMap<ServerId, Arc<Event>>,
         log_tx: mpsc::UnboundedSender<LogEntry<C>>,
         voted_for: Option<(u64, ServerId)>,

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -46,7 +46,7 @@ impl<C: 'static + Command> RawCurp<C> {
             spec_pool,
             uncommitted_pool,
             Arc::new(CurpConfig::default()),
-            Box::new(exe_tx),
+            Arc::new(exe_tx),
             sync_events,
             log_tx,
         )

--- a/engine/src/memory_engine.rs
+++ b/engine/src/memory_engine.rs
@@ -11,8 +11,10 @@ use parking_lot::RwLock;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::{
-    api::engine_api::{StorageEngine, WriteOperation},
-    api::snapshot_api::SnapshotApi,
+    api::{
+        engine_api::{StorageEngine, WriteOperation},
+        snapshot_api::SnapshotApi,
+    },
     error::EngineError,
 };
 

--- a/engine/src/proxy.rs
+++ b/engine/src/proxy.rs
@@ -1,9 +1,10 @@
 use std::path::{Path, PathBuf};
 
 use crate::{
-    error::EngineError, memory_engine::MemoryEngine, memory_engine::MemorySnapshot,
-    rocksdb_engine::RocksEngine, rocksdb_engine::RocksSnapshot, SnapshotApi, StorageEngine,
-    WriteOperation,
+    error::EngineError,
+    memory_engine::{MemoryEngine, MemorySnapshot},
+    rocksdb_engine::{RocksEngine, RocksSnapshot},
+    SnapshotApi, StorageEngine, WriteOperation,
 };
 
 #[derive(Debug)]
@@ -184,9 +185,8 @@ mod test {
 
     use clippy_utilities::NumericCast;
 
-    use crate::api::snapshot_api::SnapshotApi;
-
     use super::*;
+    use crate::api::snapshot_api::SnapshotApi;
 
     const TESTTABLES: [&'static str; 3] = ["kv", "lease", "auth"];
 

--- a/engine/src/rocksdb_engine.rs
+++ b/engine/src/rocksdb_engine.rs
@@ -1,11 +1,9 @@
 use std::{
     cmp::Ordering,
     fs, io,
-    io::Cursor,
-    io::{Error as IoError, ErrorKind},
+    io::{Cursor, Error as IoError, ErrorKind},
     iter::repeat,
-    path::Path,
-    path::PathBuf,
+    path::{Path, PathBuf},
     sync::Arc,
 };
 
@@ -21,8 +19,10 @@ use tokio::{
 };
 
 use crate::{
-    api::engine_api::{StorageEngine, WriteOperation},
-    api::snapshot_api::SnapshotApi,
+    api::{
+        engine_api::{StorageEngine, WriteOperation},
+        snapshot_api::SnapshotApi,
+    },
     error::EngineError,
 };
 

--- a/xline/src/client/restore.rs
+++ b/xline/src/client/restore.rs
@@ -4,9 +4,8 @@ use clippy_utilities::Cast;
 use engine::{Engine, EngineType, Snapshot, SnapshotApi, StorageEngine};
 use tokio::io::AsyncReadExt;
 
-use crate::{server::MAINTENANCE_SNAPSHOT_CHUNK_SIZE, storage::db::XLINE_TABLES};
-
 use super::errors::ClientError;
+use crate::{server::MAINTENANCE_SNAPSHOT_CHUNK_SIZE, storage::db::XLINE_TABLES};
 
 /// Restore snapshot to data dir
 /// # Errors

--- a/xline/src/server/barriers.rs
+++ b/xline/src/server/barriers.rs
@@ -9,14 +9,14 @@ use parking_lot::Mutex;
 #[derive(Debug)]
 pub(crate) struct IndexBarrier {
     /// Inner
-    inner: Mutex<IndexWaiterInner>,
+    inner: Mutex<IndexBarrierInner>,
 }
 
 impl IndexBarrier {
     /// Create a new index waiter
     pub(crate) fn new() -> Self {
         IndexBarrier {
-            inner: Mutex::new(IndexWaiterInner {
+            inner: Mutex::new(IndexBarrierInner {
                 last_trigger_index: 0,
                 waiters: BTreeMap::new(),
             }),
@@ -53,7 +53,7 @@ impl IndexBarrier {
 
 /// Inner of index waiter.
 #[derive(Debug)]
-struct IndexWaiterInner {
+struct IndexBarrierInner {
     /// The last index that the waiter has triggered.
     last_trigger_index: u64,
     /// Waiters of index.

--- a/xline/src/server/watch_server.rs
+++ b/xline/src/server/watch_server.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 
 /// Default channel size
-const CHANNEL_SIZE: usize = 128;
+pub(crate) const CHANNEL_SIZE: usize = 128;
 
 /// Watch Server
 #[derive(Debug)]

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -25,7 +25,7 @@ use super::{
     lease_server::LeaseServer,
     lock_server::LockServer,
     maintenance::MaintenanceServer,
-    watch_server::WatchServer,
+    watch_server::{WatchServer, CHANNEL_SIZE},
 };
 use crate::{
     header_gen::HeaderGenerator,
@@ -38,6 +38,7 @@ use crate::{
     state::State,
     storage::{
         index::Index,
+        kvwatcher::{watcher, KvWatcher},
         lease_store::LeaseCollection,
         snapshot_allocator::{MemorySnapshotAllocator, RocksSnapshotAllocator},
         storage_api::StorageApi,
@@ -62,6 +63,8 @@ where
     auth_storage: Arc<AuthStore<S>>,
     /// Lease storage
     lease_storage: Arc<LeaseStore<S>>,
+    /// Watcher
+    watcher: Arc<KvWatcher<S>>,
     /// persistent storage
     persistent: Arc<S>,
     /// Consensus client
@@ -132,8 +135,9 @@ where
             .overflow_add((min_ttl.subsec_nanos() > 0).cast());
         let lease_collection = Arc::new(LeaseCollection::new(min_ttl_secs.cast()));
         let index = Arc::new(Index::new());
-
+        let (kv_update_tx, kv_update_rx) = tokio::sync::mpsc::channel(CHANNEL_SIZE);
         let kv_storage = Arc::new(KvStore::new(
+            kv_update_tx.clone(),
             Arc::clone(&lease_collection),
             Arc::clone(&header_gen),
             Arc::clone(&persistent),
@@ -145,7 +149,7 @@ where
             Arc::clone(&header_gen),
             Arc::clone(&persistent),
             index,
-            kv_storage.kv_update_tx(),
+            kv_update_tx,
         ));
         let auth_storage = Arc::new(AuthStore::new(
             lease_collection,
@@ -153,6 +157,7 @@ where
             Arc::clone(&header_gen),
             Arc::clone(&persistent),
         ));
+        let watcher = watcher(Arc::clone(&kv_storage), kv_update_rx);
         let client = Arc::new(Client::<Command>::new(all_members.clone(), client_timeout).await);
         let index_barrier = Arc::new(IndexBarrier::new());
         let id_barrier = Arc::new(IdBarrier::new());
@@ -161,6 +166,7 @@ where
             kv_storage,
             auth_storage,
             lease_storage,
+            watcher,
             persistent,
             client,
             curp_cfg: curp_config,
@@ -384,7 +390,7 @@ where
                 Arc::clone(&self.client),
                 self.id(),
             ),
-            WatchServer::new(self.kv_storage.kv_watcher()),
+            WatchServer::new(Arc::clone(&self.watcher)),
             MaintenanceServer::new(Arc::clone(&self.persistent), Arc::clone(&self.header_gen)),
             curp_server,
         )

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -38,7 +38,7 @@ use crate::{
     state::State,
     storage::{
         index::Index,
-        kvwatcher::{watcher, KvWatcher},
+        kvwatcher::KvWatcher,
         lease_store::LeaseCollection,
         snapshot_allocator::{MemorySnapshotAllocator, RocksSnapshotAllocator},
         storage_api::StorageApi,
@@ -157,7 +157,7 @@ where
             Arc::clone(&header_gen),
             Arc::clone(&persistent),
         ));
-        let watcher = watcher(Arc::clone(&kv_storage), kv_update_rx);
+        let watcher = KvWatcher::new_arc(Arc::clone(&kv_storage), kv_update_rx);
         let client = Arc::new(Client::<Command>::new(all_members.clone(), client_timeout).await);
         let index_barrier = Arc::new(IndexBarrier::new());
         let id_barrier = Arc::new(IdBarrier::new());

--- a/xline/src/storage/auth_store/perms.rs
+++ b/xline/src/storage/auth_store/perms.rs
@@ -20,17 +20,17 @@ const DEFAULT_TOKEN_TTL: u64 = 300;
 
 /// Claims of Token
 #[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct TokenClaims {
+pub(super) struct TokenClaims {
     /// Username
-    pub(crate) username: String,
+    pub(super) username: String,
     /// Revision
-    pub(crate) revision: i64,
+    pub(super) revision: i64,
     /// Expiration
     exp: u64,
 }
 
 /// Operations of token manager
-pub(crate) trait TokenOperate {
+pub(super) trait TokenOperate {
     /// Claims type
     type Claims;
 
@@ -45,7 +45,7 @@ pub(crate) trait TokenOperate {
 }
 
 /// `TokenManager` of Json Web Token.
-pub(crate) struct JwtTokenManager {
+pub(super) struct JwtTokenManager {
     /// The key used to sign the token.
     encoding_key: EncodingKey,
     /// The key used to verify the token.
@@ -103,16 +103,16 @@ impl TokenOperate for JwtTokenManager {
 
 /// Permissions if a user
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub(crate) struct UserPermissions {
+pub(super) struct UserPermissions {
     /// `MergedRange` has read permission
-    pub(crate) read: MergedRange<Vec<u8>>,
+    pub(super) read: MergedRange<Vec<u8>>,
     /// `MergedRange` has write permission
-    pub(crate) write: MergedRange<Vec<u8>>,
+    pub(super) write: MergedRange<Vec<u8>>,
 }
 
 impl UserPermissions {
     /// New `UserPermissions`
-    pub(crate) fn new() -> Self {
+    pub(super) fn new() -> Self {
         Self {
             read: MergedRange::new(),
             write: MergedRange::new(),
@@ -120,7 +120,7 @@ impl UserPermissions {
     }
 
     /// Insert a permission to `UserPermissions`
-    pub(crate) fn insert(&mut self, perm: Permission) {
+    pub(super) fn insert(&mut self, perm: Permission) {
         let range = KeyRange::new(perm.key, perm.range_end).unpack();
         #[allow(clippy::unwrap_used)] // safe unwrap
         match Type::from_i32(perm.perm_type).unwrap() {
@@ -140,11 +140,11 @@ impl UserPermissions {
 
 /// Permissions cache
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct PermissionCache {
+pub(super) struct PermissionCache {
     /// Permissions of users
-    pub(crate) user_permissions: HashMap<String, UserPermissions>,
+    pub(super) user_permissions: HashMap<String, UserPermissions>,
     /// Role to users map
-    pub(crate) role_to_users_map: HashMap<String, Vec<String>>,
+    pub(super) role_to_users_map: HashMap<String, Vec<String>>,
 }
 
 impl PermissionCache {

--- a/xline/src/storage/auth_store/store.rs
+++ b/xline/src/storage/auth_store/store.rs
@@ -1152,6 +1152,17 @@ mod test {
     };
 
     #[test]
+    fn test_token_assign_and_verify() {
+        let db = DB::open(&StorageConfig::Memory).unwrap();
+        let store = init_auth_store(db);
+        let current_revision = store.revision();
+        let token = store.assign("xline").unwrap();
+        let claim = store.verify_token(token.as_str()).unwrap();
+        assert_eq!(claim.revision, current_revision);
+        assert_eq!(claim.username, "xline");
+    }
+
+    #[test]
     fn test_role_grant_permission() -> Result<(), ExecuteError> {
         let db = DB::open(&StorageConfig::Memory)?;
         let store = init_auth_store(db);

--- a/xline/src/storage/auth_store/store.rs
+++ b/xline/src/storage/auth_store/store.rs
@@ -119,7 +119,7 @@ where
     }
 
     /// verify token
-    pub(crate) fn verify_token(&self, token: &str) -> Result<TokenClaims, ExecuteError> {
+    fn verify_token(&self, token: &str) -> Result<TokenClaims, ExecuteError> {
         match self.token_manager {
             Some(ref token_manager) => token_manager
                 .verify(token)
@@ -151,11 +151,7 @@ where
     }
 
     /// get user permissions
-    pub(crate) fn get_user_permissions(
-        &self,
-        user: &User,
-        skip_role: Option<&str>,
-    ) -> UserPermissions {
+    fn get_user_permissions(&self, user: &User, skip_role: Option<&str>) -> UserPermissions {
         let mut user_permission = UserPermissions::new();
         for role_name in &user.roles {
             if skip_role.map_or(false, |r| r == role_name) {

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -11,7 +11,7 @@ use tracing::{debug, warn};
 
 use super::{
     index::{Index, IndexOperate},
-    kvwatcher::KvWatcher,
+    kvwatcher::{watcher, KvWatcher},
     lease_store::LeaseCollection,
     storage_api::StorageApi,
     Revision,
@@ -85,7 +85,7 @@ where
             storage,
             index,
         ));
-        let kv_watcher = Arc::new(KvWatcher::new(Arc::clone(&inner), kv_update_rx));
+        let kv_watcher = watcher(Arc::clone(&inner), kv_update_rx);
         Self { inner, kv_watcher }
     }
 

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -747,7 +747,7 @@ mod test {
     use super::*;
     use crate::{
         rpc::RequestOp,
-        storage::{db::DB, kvwatcher::watcher},
+        storage::{db::DB, kvwatcher::KvWatcher},
     };
 
     const CHANNEL_SIZE: usize = 128;
@@ -979,7 +979,7 @@ mod test {
             db,
             index,
         ));
-        let _watcher = watcher(Arc::clone(&storage), kv_update_rx);
+        let _watcher = KvWatcher::new_arc(Arc::clone(&storage), kv_update_rx);
         storage
     }
 }

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -14,7 +14,7 @@ use tokio::sync::mpsc;
 use utils::parking_lot_lock::RwLockMap;
 
 use super::storage_api::StorageApi;
-use crate::{rpc::Event, server::command::KeyRange, storage::kv_store::KvStoreBackend};
+use crate::{rpc::Event, server::command::KeyRange, storage::kv_store::KvStore};
 
 /// Watch ID
 pub(crate) type WatchId = i64;
@@ -122,7 +122,7 @@ where
     S: StorageApi,
 {
     /// KV storage
-    storage: Arc<KvStoreBackend<S>>,
+    storage: Arc<KvStore<S>>,
     /// Watch indexes
     watcher_map: RwLock<WatcherMap>,
 }
@@ -184,8 +184,8 @@ impl WatcherMap {
 }
 
 /// Boot up a watcher task and return an `Arc<KvWatcher<S>>`
-pub(super) fn watcher<S: StorageApi>(
-    storage: Arc<KvStoreBackend<S>>,
+pub(crate) fn watcher<S: StorageApi>(
+    storage: Arc<KvStore<S>>,
     mut kv_update_rx: mpsc::Receiver<(i64, Vec<Event>)>,
 ) -> Arc<KvWatcher<S>> {
     let kv_watcher = Arc::new(KvWatcher::new(storage));
@@ -262,7 +262,7 @@ where
     S: StorageApi,
 {
     /// New `KvWatchInner`
-    fn new(storage: Arc<KvStoreBackend<S>>) -> Self {
+    fn new(storage: Arc<KvStore<S>>) -> Self {
         Self {
             storage,
             watcher_map: RwLock::new(WatcherMap::new()),

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -261,7 +261,7 @@ impl<S> KvWatcher<S>
 where
     S: StorageApi,
 {
-    /// New `KvWatchInner`
+    /// New `KvWatcher`
     fn new(storage: Arc<KvStore<S>>) -> Self {
         Self {
             storage,

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -121,16 +121,6 @@ pub(crate) struct KvWatcher<S>
 where
     S: StorageApi,
 {
-    /// Inner data
-    inner: Arc<KvWatcherInner<S>>,
-}
-
-/// KV watcher inner data
-#[derive(Debug)]
-struct KvWatcherInner<S>
-where
-    S: StorageApi,
-{
     /// KV storage
     storage: Arc<KvStoreBackend<S>>,
     /// Watch indexes
@@ -193,24 +183,19 @@ impl WatcherMap {
     }
 }
 
-impl<S> KvWatcher<S>
-where
-    S: StorageApi,
-{
-    /// New `KvWatcher`
-    pub(super) fn new(
-        storage: Arc<KvStoreBackend<S>>,
-        mut kv_update_rx: mpsc::Receiver<(i64, Vec<Event>)>,
-    ) -> Self {
-        let inner = Arc::new(KvWatcherInner::new(storage));
-        let inner_clone = Arc::clone(&inner);
-        let _handle = tokio::spawn(async move {
-            while let Some(updates) = kv_update_rx.recv().await {
-                inner_clone.handle_kv_updates(updates).await;
-            }
-        });
-        Self { inner }
-    }
+/// Boot up a watcher task and return an `Arc<KvWatcher<S>>`
+pub(super) fn watcher<S: StorageApi>(
+    storage: Arc<KvStoreBackend<S>>,
+    mut kv_update_rx: mpsc::Receiver<(i64, Vec<Event>)>,
+) -> Arc<KvWatcher<S>> {
+    let kv_watcher = Arc::new(KvWatcher::new(storage));
+    let watcher = Arc::clone(&kv_watcher);
+    let _handle = tokio::spawn(async move {
+        while let Some(updates) = kv_update_rx.recv().await {
+            watcher.handle_kv_updates(updates).await;
+        }
+    });
+    kv_watcher
 }
 
 /// Operations of KV watcher
@@ -244,37 +229,6 @@ where
         filters: Vec<i32>,
         event_tx: mpsc::Sender<WatchEvent>,
     ) -> (Vec<Event>, i64) {
-        self.inner
-            .watch(id, key_range, start_rev, filters, event_tx)
-    }
-
-    /// Cancel a watch from KV store
-    fn cancel(&self, id: WatchId) -> i64 {
-        self.inner.cancel(id)
-    }
-}
-
-impl<S> KvWatcherInner<S>
-where
-    S: StorageApi,
-{
-    /// New `KvWatchInner`
-    fn new(storage: Arc<KvStoreBackend<S>>) -> Self {
-        Self {
-            storage,
-            watcher_map: RwLock::new(WatcherMap::new()),
-        }
-    }
-
-    /// Create a watch to KV store
-    fn watch(
-        &self,
-        id: WatchId,
-        key_range: KeyRange,
-        start_rev: i64,
-        filters: Vec<i32>,
-        event_tx: mpsc::Sender<WatchEvent>,
-    ) -> (Vec<Event>, i64) {
         let watcher = Watcher::new(key_range.clone(), id, start_rev, filters, event_tx);
 
         let revision = self.storage.revision();
@@ -296,10 +250,23 @@ where
     }
 
     /// Cancel a watch from KV store
-    fn cancel(&self, watch_id: WatchId) -> i64 {
+    fn cancel(&self, id: WatchId) -> i64 {
         let revision = self.storage.revision();
-        self.watcher_map.write().remove(watch_id);
+        self.watcher_map.write().remove(id);
         revision
+    }
+}
+
+impl<S> KvWatcher<S>
+where
+    S: StorageApi,
+{
+    /// New `KvWatchInner`
+    fn new(storage: Arc<KvStoreBackend<S>>) -> Self {
+        Self {
+            storage,
+            watcher_map: RwLock::new(WatcherMap::new()),
+        }
     }
 
     /// Handle KV store updates

--- a/xline/src/storage/lease_store/mod.rs
+++ b/xline/src/storage/lease_store/mod.rs
@@ -74,7 +74,6 @@ where
     DB: StorageApi,
 {
     /// New `LeaseStore`
-    #[allow(clippy::integer_arithmetic)] // Introduced by tokio::select!
     pub(crate) fn new(
         lease_collection: Arc<LeaseCollection>,
         state: Arc<State>,


### PR DESCRIPTION
Please briefly answer these questions:
refactor kv server dependencies, close [#250], [#259] 
This pr is based on [#245]

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Viewing #250, and #259 for more details. 

* what changes does this pull request make?
1. Merge `KvWatcherInner` and `KvWatcher` into a `KvWatcher`. All the things a `KvWatcherInner` does is spawn a watcher task and construct a `KvWatcherInner` object. A function watcher is better suited to do such a thing than a concrete structure `KvWatcher` in that a function is stateless, making the dependency graph clearer.
2. Merge `KvStoreBackend` and `KvStore` together. The reason why we need a `KvStoreBackend` is that the `KvStore` need to keep a `KvWatcher` as its member variable. But it's unnecessary, the `KvStore` never uses the `KvWatcher`.
3. Place the `KvWatcher` constructed logic into `XlineServer`.
4. Make some data structures depend on interfaces rather than concrete data types.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
No