### PR TITLE
Refactor/remove watch event

### DIFF
--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -278,6 +278,7 @@ where
             res = sync_res;
         }
         self.persistent.flush_ops(ops)?;
+        self.kv_storage.mark_index_available(res.revision());
         self.id_barrier.trigger(cmd.id());
         self.index_barrier.trigger(index);
         Ok(res)

--- a/xline/src/storage/index.rs
+++ b/xline/src/storage/index.rs
@@ -24,7 +24,7 @@ impl Index {
     /// Filter out `KeyRevision` that is less than one revision and convert to `Revision`
     fn filter_revision(revs: &[KeyRevision], revision: i64) -> Vec<Revision> {
         revs.iter()
-            .filter(|rev| rev.mod_revision >= revision)
+            .filter(|rev| rev.mod_revision >= revision && rev.available)
             .map(KeyRevision::as_revision)
             .collect()
     }
@@ -33,7 +33,7 @@ impl Index {
     fn get_revision(revs: &[KeyRevision], revision: i64) -> Option<Revision> {
         // TODO: handle future revision
         let rev = if revision <= 0 {
-            revs.last()
+            revs.iter().rev().find(|kr| kr.available)
         } else {
             let idx = match revs.binary_search_by(|rev| rev.mod_revision.cmp(&revision)) {
                 Ok(idx) => idx,
@@ -48,6 +48,16 @@ impl Index {
         };
         rev.filter(|kr| !kr.is_deleted())
             .map(KeyRevision::as_revision)
+    }
+
+    /// Mark the `KeyRevision` as available
+    pub(crate) fn mark_available(&self, revision: i64) {
+        let mut index = self.index.lock();
+        for revs in index.values_mut() {
+            if let Some(rev) = revs.iter_mut().find(|rev| rev.mod_revision == revision) {
+                rev.available = true;
+            }
+        }
     }
 }
 
@@ -214,15 +224,30 @@ impl IndexOperate for Index {
         create_revision: i64,
         version: i64,
     ) {
-        let mut index = self.index.lock();
-        let new_rev = KeyRevision::new(create_revision, version, revision, sub_revision);
-        index.entry(key).or_insert_with(Vec::new).push(new_rev);
+        let mut new_rev = KeyRevision::new(create_revision, version, revision, sub_revision);
+        new_rev.available = true;
+        self.index
+            .lock()
+            .entry(key)
+            .or_insert_with(Vec::new)
+            .push(new_rev);
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn new_available_key_revision(
+        create_revision: i64,
+        version: i64,
+        revision: i64,
+        sub_revision: i64,
+    ) -> KeyRevision {
+        let mut rev = KeyRevision::new(create_revision, version, revision, sub_revision);
+        rev.available = true;
+        rev
+    }
 
     fn init_and_test_insert() -> Index {
         let index = Index::new();
@@ -231,14 +256,18 @@ mod test {
         index.insert_or_update_revision(b"key", 2, 2);
         index.insert_or_update_revision(b"key", 3, 1);
 
+        index.mark_available(1);
+        index.mark_available(2);
+        index.mark_available(3);
+
         assert_eq!(
             *index.index.lock(),
             BTreeMap::from_iter(vec![(
                 b"key".to_vec(),
                 vec![
-                    KeyRevision::new(1, 1, 1, 3),
-                    KeyRevision::new(1, 2, 2, 2),
-                    KeyRevision::new(1, 3, 3, 1),
+                    new_available_key_revision(1, 1, 1, 3),
+                    new_available_key_revision(1, 2, 2, 2),
+                    new_available_key_revision(1, 3, 3, 1),
                 ]
             ),])
         );
@@ -269,9 +298,9 @@ mod test {
             BTreeMap::from_iter(vec![(
                 b"key".to_vec(),
                 vec![
-                    KeyRevision::new(1, 1, 1, 3),
-                    KeyRevision::new(1, 2, 2, 2),
-                    KeyRevision::new(1, 3, 3, 1),
+                    new_available_key_revision(1, 1, 1, 3),
+                    new_available_key_revision(1, 2, 2, 2),
+                    new_available_key_revision(1, 3, 3, 1),
                     KeyRevision::new_deletion(4, 0),
                 ]
             ),])
@@ -287,10 +316,16 @@ mod test {
         assert_eq!(
             *index.index.lock(),
             BTreeMap::from_iter(vec![
-                (b"foo".to_vec(), vec![KeyRevision::new(4, 1, 4, 0)]),
+                (
+                    b"foo".to_vec(),
+                    vec![new_available_key_revision(4, 1, 4, 0)]
+                ),
                 (
                     b"key".to_vec(),
-                    vec![KeyRevision::new(2, 1, 2, 0), KeyRevision::new(2, 2, 3, 0)]
+                    vec![
+                        new_available_key_revision(2, 1, 2, 0),
+                        new_available_key_revision(2, 2, 3, 0)
+                    ],
                 ),
             ])
         );

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -427,6 +427,7 @@ where
     }
 
     /// Get `KeyValue` start from a revision and convert to `Event`
+    /// Return the last event's revision and all events
     pub(crate) fn get_events_from_revision(
         &self,
         key_range: KeyRange,

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -421,14 +421,15 @@ where
     }
 
     /// Get `KeyValue` start from a revision and convert to `Event`
-    pub(crate) fn get_event_from_revision(
+    pub(crate) fn get_events_from_revision(
         &self,
         key_range: KeyRange,
         revision: i64,
-    ) -> Result<Vec<Event>, ExecuteError> {
+    ) -> Result<(i64, Vec<Event>), ExecuteError> {
         let revisions =
             self.index
                 .get_from_rev(key_range.range_start(), key_range.range_end(), revision);
+        let last_rev = revisions.last().map_or(0, Revision::revision);
         let events = self
             .get_values(&revisions)?
             .into_iter()
@@ -449,7 +450,7 @@ where
                 event
             })
             .collect();
-        Ok(events)
+        Ok((last_rev, events))
     }
 }
 

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{HashMap, HashSet},
     hash::Hash,
     sync::{
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicI64, Ordering},
         Arc,
     },
 };
@@ -19,6 +19,22 @@ use crate::{rpc::Event, server::command::KeyRange, storage::kv_store::KvStoreBac
 
 /// Watch ID
 pub(crate) type WatchId = i64;
+
+/// Watch ID generator
+#[derive(Debug)]
+pub(crate) struct WatchIdGenerator(AtomicI64);
+
+impl WatchIdGenerator {
+    /// Create a new revision
+    pub(crate) fn new(rev: i64) -> Self {
+        Self(AtomicI64::new(rev))
+    }
+
+    /// Get the next revision number
+    pub(crate) fn next(&self) -> i64 {
+        self.0.fetch_add(1, Ordering::AcqRel).wrapping_add(1)
+    }
+}
 
 /// Watcher
 #[derive(Debug)]

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -414,7 +414,7 @@ mod test {
     use super::*;
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
-    async fn it_works() {
+    async fn watcher_should_get_all_events() {
         let (store, db) = init_empty_store();
         let mut map = BTreeMap::new();
         let handle = tokio::spawn({
@@ -429,8 +429,9 @@ mod test {
                         }
                         .into(),
                     );
-                    let (_res, ops) = store.after_sync(&req).await.unwrap();
+                    let (sync_res, ops) = store.after_sync(&req).await.unwrap();
                     db.flush_ops(ops).unwrap();
+                    store.mark_index_available(sync_res.revision());
                 }
             }
         });

--- a/xline/src/storage/revision.rs
+++ b/xline/src/storage/revision.rs
@@ -11,6 +11,9 @@ pub(crate) struct KeyRevision {
     pub(crate) mod_revision: i64,
     /// Sub revision in one transaction
     pub(crate) sub_revision: i64,
+    /// Available flag
+    // true means this revision is written to storage
+    pub(crate) available: bool,
 }
 
 /// Revision
@@ -68,6 +71,7 @@ impl KeyRevision {
             version,
             mod_revision,
             sub_revision,
+            available: false,
         }
     }
 
@@ -78,6 +82,7 @@ impl KeyRevision {
             version: 0,
             mod_revision,
             sub_revision,
+            available: false,
         }
     }
 


### PR DESCRIPTION
Please briefly answer these questions:
one pr of #253 
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Reduce task work
* what changes does this pull request make?
Let the watcher directly hold `response_tx` and respond directly to the client
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no