### PR TITLE
fix #263

### DIFF
--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -41,6 +41,7 @@ chrono = { version = "0.4.24", default-features = false, features = [
   "std",
 ] }
 uuid = { version = "1.3.1", features = ["v4"] }
+bytes = "1.4.0"
 
 [dev-dependencies]
 itertools = "0.10.3"
@@ -52,3 +53,4 @@ once_cell = "1.17.0"
 
 [build-dependencies]
 tonic-build = "0.7.2"
+prost-build = "0.10.3"

--- a/curp/build.rs
+++ b/curp/build.rs
@@ -1,5 +1,7 @@
 fn main() {
+    let mut prost_config = prost_build::Config::new();
+    prost_config.bytes([".messagepb.InstallSnapshotRequest"]);
     tonic_build::configure()
-        .compile(&["./proto/message.proto"], &["./proto/"])
+        .compile_with_config(prost_config, &["./proto/message.proto"], &["./proto/"])
         .unwrap_or_else(|e| panic!("Failed to compile proto, error is {:?}", e));
 }

--- a/curp/src/rpc/connect.rs
+++ b/curp/src/rpc/connect.rs
@@ -292,7 +292,7 @@ fn install_snapshot_stream(
             let len: u64 =
                 std::cmp::min(snapshot.size() - offset, SNAPSHOT_CHUNK_SIZE).numeric_cast();
             let mut data = BytesMut::with_capacity(len.numeric_cast());
-            if let Err(e) = snapshot.read_exact(&mut data).await {
+            if let Err(e) = snapshot.read_buf_exact(&mut data).await {
                 error!("read snapshot error, {e}");
                 break;
             }

--- a/curp/src/server/curp_node.rs
+++ b/curp/src/server/curp_node.rs
@@ -222,17 +222,15 @@ impl<C: 'static + Command> CurpNode<C> {
             ) {
                 return Ok(InstallSnapshotResponse::new(self.curp.term()));
             }
-            snapshot
-                .write_all(req.data.as_slice())
-                .await
-                .map_err(|err| {
-                    error!("can't write snapshot data, {err:?}");
-                    err
-                })?;
+            let req_data_len = req.data.len().numeric_cast::<u64>();
+            snapshot.write_all(req.data).await.map_err(|err| {
+                error!("can't write snapshot data, {err:?}");
+                err
+            })?;
             if req.done {
                 debug_assert_eq!(
                     snapshot.size(),
-                    req.offset + req.data.len().numeric_cast::<u64>(),
+                    req.offset + req_data_len,
                     "snapshot corrupted"
                 );
                 let meta = SnapshotMeta {

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -26,3 +26,5 @@ tokio = { version = "1.26.0", features = [
     "rt-multi-thread",
     "io-util",
 ] }
+bytes = "1.4.0"
+tokio-util = { version = "0.7.8", features = ["io"] }

--- a/engine/src/api/snapshot_api.rs
+++ b/engine/src/api/snapshot_api.rs
@@ -1,3 +1,5 @@
+use bytes::{Bytes, BytesMut};
+
 /// This trait is a abstraction of the snapshot, We can Read/Write the snapshot like a file.
 #[async_trait::async_trait]
 pub trait SnapshotApi: Send + Sync + std::fmt::Debug {
@@ -8,10 +10,10 @@ pub trait SnapshotApi: Send + Sync + std::fmt::Debug {
     fn rewind(&mut self) -> std::io::Result<()>;
 
     /// Read the snapshot to the given buffer
-    async fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()>;
+    async fn read_exact(&mut self, buf: &mut BytesMut) -> std::io::Result<()>;
 
     /// Write the given buffer to the snapshot
-    async fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()>;
+    async fn write_all(&mut self, buf: Bytes) -> std::io::Result<()>;
 
     /// Clean files of current snapshot
     async fn clean(&mut self) -> std::io::Result<()>;

--- a/engine/src/api/snapshot_api.rs
+++ b/engine/src/api/snapshot_api.rs
@@ -1,3 +1,5 @@
+use std::io::{Error, ErrorKind};
+
 use bytes::{Bytes, BytesMut};
 
 /// This trait is a abstraction of the snapshot, We can Read/Write the snapshot like a file.
@@ -9,8 +11,30 @@ pub trait SnapshotApi: Send + Sync + std::fmt::Debug {
     /// Rewind the snapshot to the beginning
     fn rewind(&mut self) -> std::io::Result<()>;
 
-    /// Read the snapshot to the given buffer
-    async fn read_exact(&mut self, buf: &mut BytesMut) -> std::io::Result<()>;
+    /// Pull some bytes of the snapshot to the given uninitialized buffer
+    async fn read_buf(&mut self, buf: &mut BytesMut) -> std::io::Result<()>;
+
+    /// Read the exact capacity of the given uninitialized buffer
+    #[inline]
+    async fn read_buf_exact(&mut self, buf: &mut BytesMut) -> std::io::Result<()> {
+        while buf.len() < buf.capacity() {
+            let prev_len = buf.len();
+            match self.read_buf(buf).await {
+                Ok(()) => {}
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(e) => return Err(e),
+            }
+
+            if buf.len() == prev_len {
+                return Err(Error::new(
+                    ErrorKind::UnexpectedEof,
+                    "failed to fill whole buffer",
+                ));
+            }
+        }
+
+        Ok(())
+    }
 
     /// Write the given buffer to the snapshot
     async fn write_all(&mut self, buf: Bytes) -> std::io::Result<()>;

--- a/engine/src/memory_engine.rs
+++ b/engine/src/memory_engine.rs
@@ -1,7 +1,7 @@
 use std::{
     cmp::Ordering,
     collections::HashMap,
-    io::{Cursor, ErrorKind, Seek},
+    io::{Cursor, Seek},
     path::Path,
     sync::Arc,
 };
@@ -191,26 +191,8 @@ impl SnapshotApi for MemorySnapshot {
     }
 
     #[inline]
-    async fn read_exact(&mut self, buf: &mut BytesMut) -> std::io::Result<()> {
-        while buf.len() < buf.capacity() {
-            match read_buf(&mut self.data, buf).await {
-                Ok(n) => {
-                    if 0 == n {
-                        break;
-                    }
-                }
-                Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
-                Err(e) => return Err(e),
-            }
-        }
-        if buf.len() == buf.capacity() {
-            Ok(())
-        } else {
-            Err(std::io::Error::new(
-                ErrorKind::UnexpectedEof,
-                "failed to fill whole buffer",
-            ))
-        }
+    async fn read_buf(&mut self, buf: &mut BytesMut) -> std::io::Result<()> {
+        read_buf(&mut self.data, buf).await.map(|_n| ())
     }
 
     #[inline]

--- a/engine/src/memory_engine.rs
+++ b/engine/src/memory_engine.rs
@@ -6,9 +6,11 @@ use std::{
     sync::Arc,
 };
 
+use bytes::{Bytes, BytesMut};
 use clippy_utilities::NumericCast;
 use parking_lot::RwLock;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::io::AsyncWriteExt;
+use tokio_util::io::read_buf;
 
 use crate::{
     api::{
@@ -189,13 +191,13 @@ impl SnapshotApi for MemorySnapshot {
     }
 
     #[inline]
-    async fn read_exact(&mut self, buf: &mut [u8]) -> std::io::Result<()> {
-        self.data.read_exact(buf).await.map(drop)
+    async fn read_exact(&mut self, buf: &mut BytesMut) -> std::io::Result<()> {
+        read_buf(&mut self.data, buf).await.map(drop)
     }
 
     #[inline]
-    async fn write_all(&mut self, buf: &[u8]) -> std::io::Result<()> {
-        self.data.write_all(buf).await
+    async fn write_all(&mut self, buf: Bytes) -> std::io::Result<()> {
+        self.data.write_all(&buf).await
     }
 
     #[inline]

--- a/engine/src/proxy.rs
+++ b/engine/src/proxy.rs
@@ -157,10 +157,18 @@ impl SnapshotApi for Snapshot {
     }
 
     #[inline]
-    async fn read_exact(&mut self, buf: &mut BytesMut) -> std::io::Result<()> {
+    async fn read_buf(&mut self, buf: &mut BytesMut) -> std::io::Result<()> {
         match *self {
-            Snapshot::Memory(ref mut s) => s.read_exact(buf).await,
-            Snapshot::Rocks(ref mut s) => s.read_exact(buf).await,
+            Snapshot::Memory(ref mut s) => s.read_buf(buf).await,
+            Snapshot::Rocks(ref mut s) => s.read_buf(buf).await,
+        }
+    }
+
+    #[inline]
+    async fn read_buf_exact(&mut self, buf: &mut BytesMut) -> std::io::Result<()> {
+        match *self {
+            Snapshot::Memory(ref mut s) => s.read_buf_exact(buf).await,
+            Snapshot::Rocks(ref mut s) => s.read_buf_exact(buf).await,
         }
     }
 
@@ -338,7 +346,7 @@ mod test {
             assert!(engine.write_batch(vec![put], false).is_ok());
 
             let mut buf = BytesMut::with_capacity(snapshot.size().numeric_cast());
-            snapshot.read_exact(&mut buf).await.unwrap();
+            snapshot.read_buf_exact(&mut buf).await.unwrap();
 
             buf.extend([0u8; 100]); // add some padding, will be ignored when receiving
 

--- a/xline/Cargo.toml
+++ b/xline/Cargo.toml
@@ -58,6 +58,8 @@ priority-queue = "1.3.0"
 futures = "0.3.25"
 sha2 = "0.10.6"
 async-stream = "0.3.5"
+bytes = "1.4.0"
+tokio-util = { version = "0.7.8", features = ["io"] }
 
 [build-dependencies]
 tonic-build = "0.7.2"

--- a/xline/src/server/maintenance.rs
+++ b/xline/src/server/maintenance.rs
@@ -126,7 +126,7 @@ where
                 let buf_size = std::cmp::min(MAINTENANCE_SNAPSHOT_CHUNK_SIZE, remain_size);
                 let mut buf = BytesMut::with_capacity(buf_size.cast());
                 remain_size = remain_size.overflow_sub(buf_size);
-                snapshot.read_exact(&mut buf).await.map_err(|_e| {tonic::Status::internal("snapshot read failed")})?;
+                snapshot.read_buf_exact(&mut buf).await.map_err(|_e| {tonic::Status::internal("snapshot read failed")})?;
                 // etcd client will use the size of the snapshot to determine whether checksum is included,
                 // and the check method size % 512 == sha256.size, So we need to pad snapshots to multiples
                 // of 512 bytes
@@ -212,7 +212,7 @@ mod test {
             .unwrap();
         let size = snap2.size().cast();
         let mut snap2_data = BytesMut::with_capacity(size);
-        snap2.read_exact(&mut snap2_data).await.unwrap();
+        snap2.read_buf_exact(&mut snap2_data).await.unwrap();
         let snap1_data = recv_data[..size].to_vec();
         assert_eq!(snap1_data, snap2_data);
 


### PR DESCRIPTION
fix #263 
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    improve the read and write logic for the RocksSnapshot

* what changes does this pull request make?

    change of SnapshotApi in read_exact and write_all funtions and all associated calls on these funtions

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

    read_exact and write_all funtions now use bytes::{Bytes, BytesMut} as parameter types