### PR TITLE
Refactor/add victim

### DIFF
--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -93,6 +93,10 @@ pub struct ClusterConfig {
     #[getset(get = "pub")]
     #[serde(with = "duration_format", default = "default_range_retry_timeout")]
     range_retry_timeout: Duration,
+    /// Sync victims interval
+    #[getset(get = "pub")]
+    #[serde(with = "duration_format", default = "default_sync_victims_interval")]
+    sync_victims_interval: Duration,
 }
 
 impl ClusterConfig {
@@ -106,6 +110,7 @@ impl ClusterConfig {
         curp: CurpConfig,
         client_timeout: ClientTimeout,
         range_retry_timeout: Duration,
+        sync_victims_interval: Duration,
     ) -> Self {
         Self {
             name,
@@ -114,6 +119,7 @@ impl ClusterConfig {
             curp_config: curp,
             client_timeout,
             range_retry_timeout,
+            sync_victims_interval,
         }
     }
 }
@@ -281,6 +287,13 @@ pub const fn default_cmd_workers() -> u8 {
 #[inline]
 pub const fn default_range_retry_timeout() -> Duration {
     Duration::from_secs(2)
+}
+
+/// default sync victims interval
+#[must_use]
+#[inline]
+pub const fn default_sync_victims_interval() -> Duration {
+    Duration::from_millis(10)
 }
 
 /// default gc interval
@@ -607,7 +620,9 @@ mod tests {
             r#"[cluster]
             name = 'node1'
             is_leader = true
-            range_retry_timeout = '3s'
+            range_retry_timeout = '3s'            
+            sync_victims_interval = '20ms'
+
 
             [cluster.members]
             node1 = '127.0.0.1:2379'
@@ -656,7 +671,7 @@ mod tests {
         );
 
         let range_retry_timeout = Duration::from_secs(3);
-
+        let sync_victims_interval = Duration::from_millis(20);
         assert_eq!(
             config.cluster,
             ClusterConfig::new(
@@ -669,7 +684,8 @@ mod tests {
                 true,
                 curp_config,
                 client_timeout,
-                range_retry_timeout
+                range_retry_timeout,
+                sync_victims_interval,
             )
         );
 
@@ -738,7 +754,8 @@ mod tests {
                 true,
                 CurpConfig::default(),
                 ClientTimeout::default(),
-                default_range_retry_timeout()
+                default_range_retry_timeout(),
+                default_sync_victims_interval()
             )
         );
 

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -134,6 +134,7 @@
         clippy::unwrap_used,
         clippy::as_conversions,
         clippy::shadow_unrelated,
+        clippy::integer_arithmetic
     )
 )]
 

--- a/xline/src/server/watch_server.rs
+++ b/xline/src/server/watch_server.rs
@@ -185,6 +185,7 @@ where
             key_range,
             req.start_revision,
             req.filters,
+            Arc::clone(&self.stop_notify),
             self.event_tx.clone(),
         );
         assert!(
@@ -361,7 +362,7 @@ mod test {
         let collection = Arc::new(Mutex::new(HashMap::new()));
         let collection_c = Arc::clone(&collection);
         let _ = mock_watcher.expect_watch().times(2).returning({
-            move |x, _, _, _, _| {
+            move |x, _, _, _, _, _| {
                 let mut c = collection_c.lock();
                 let e = c.entry(x).or_insert(0);
                 *e += 1;

--- a/xline/src/server/watch_server.rs
+++ b/xline/src/server/watch_server.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Default channel size
-pub(crate) const CHANNEL_SIZE: usize = 128;
+pub(crate) const CHANNEL_SIZE: usize = 1024;
 
 /// Watch Server
 #[derive(Debug)]

--- a/xline/src/server/xline_server.rs
+++ b/xline/src/server/xline_server.rs
@@ -16,7 +16,7 @@ use tokio::{net::TcpListener, sync::broadcast};
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::transport::Server;
 use tracing::info;
-use utils::config::{ClientTimeout, CurpConfig, StorageConfig};
+use utils::config::{ClientTimeout, CurpConfig, ServerTimeout, StorageConfig};
 
 use super::{
     auth_server::AuthServer,
@@ -113,8 +113,7 @@ where
         key_pair: Option<(EncodingKey, DecodingKey)>,
         curp_config: CurpConfig,
         client_timeout: ClientTimeout,
-        range_retry_timeout: Duration,
-        sync_victims_interval: Duration,
+        server_timeout: ServerTimeout,
         storage_config: StorageConfig,
         persistent: Arc<S>,
     ) -> Self {
@@ -171,7 +170,7 @@ where
             Arc::clone(&kv_storage),
             kv_update_rx,
             Arc::clone(&shutdown_trigger),
-            sync_victims_interval,
+            *server_timeout.sync_victims_interval(),
         );
         let client = Arc::new(Client::<Command>::new(all_members.clone(), client_timeout).await);
         let index_barrier = Arc::new(IndexBarrier::new());
@@ -191,7 +190,7 @@ where
             auth_revision,
             index_barrier,
             id_barrier,
-            range_retry_timeout,
+            range_retry_timeout: *server_timeout.range_retry_timeout(),
             shutdown_trigger,
         }
     }

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -748,6 +748,8 @@ where
 
 #[cfg(test)]
 mod test {
+    use std::time::Duration;
+
     use utils::config::StorageConfig;
 
     use super::*;
@@ -800,7 +802,13 @@ mod test {
             db,
             index,
         ));
-        let _watcher = KvWatcher::new_arc(Arc::clone(&storage), kv_update_rx);
+        let shutdown_trigger = Arc::new(event_listener::Event::new());
+        let _watcher = KvWatcher::new_arc(
+            Arc::clone(&storage),
+            kv_update_rx,
+            shutdown_trigger,
+            Duration::from_millis(10),
+        );
         storage
     }
 

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -759,7 +759,7 @@ mod test {
         storage::{db::DB, kvwatcher::KvWatcher},
     };
 
-    const CHANNEL_SIZE: usize = 128;
+    const CHANNEL_SIZE: usize = 1024;
 
     fn sort_req(sort_order: SortOrder, sort_target: SortTarget) -> RangeRequest {
         RangeRequest {

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -8,6 +8,7 @@ use std::{
 };
 
 use clippy_utilities::OverflowArithmetic;
+use itertools::Itertools;
 use log::warn;
 use parking_lot::RwLock;
 use tokio::sync::mpsc;
@@ -132,9 +133,9 @@ where
 #[derive(Debug)]
 struct WatcherMap {
     /// All watchers
-    watchers: HashMap<WatchId, Arc<Watcher>>,
+    watchers: HashMap<WatchId, Watcher>,
     /// Index for watchers
-    index: HashMap<KeyRange, HashSet<Arc<Watcher>>>,
+    index: HashMap<KeyRange, HashSet<WatchId>>,
 }
 
 impl WatcherMap {
@@ -147,20 +148,18 @@ impl WatcherMap {
     }
 
     /// Insert a new watcher to the map and create. Internally, it will create a index for this watcher.
-    fn insert(&mut self, watcher: Arc<Watcher>) {
+    fn insert(&mut self, watcher: Watcher) {
         let key_range = watcher.key_range().clone();
         let watch_id = watcher.watch_id();
         assert!(
-            self.watchers
-                .insert(watch_id, Arc::clone(&watcher))
-                .is_none(),
+            self.watchers.insert(watch_id, watcher).is_none(),
             "can't insert a watcher twice"
         );
         assert!(
             self.index
                 .entry(key_range)
                 .or_insert_with(HashSet::new)
-                .insert(watcher),
+                .insert(watch_id),
             "can't insert a watcher twice"
         );
     }
@@ -175,7 +174,10 @@ impl WatcherMap {
                 .index
                 .get_mut(key_range)
                 .expect("no such watcher in index");
-            assert!(watchers.remove(&watcher), "no such watcher in index");
+            assert!(
+                watchers.remove(&watcher.watch_id()),
+                "no such watcher in index"
+            );
             watchers.is_empty()
         };
         if is_empty {
@@ -242,7 +244,7 @@ where
             watcher.notify((last_revision, initial_events));
             watcher.start_rev = last_revision.overflow_add(1);
         }
-        watcher_map_w.insert(Arc::new(watcher));
+        watcher_map_w.insert(watcher);
     }
 
     /// Cancel a watch from KV store
@@ -278,9 +280,9 @@ where
     /// Handle KV store updates
     fn handle_kv_updates(&self, (revision, all_events): (i64, Vec<Event>)) {
         self.watcher_map.map_read(|watcher_map_r| {
-            let mut watcher_events: HashMap<&Arc<Watcher>, Vec<Event>> = HashMap::new();
+            let mut watcher_events: HashMap<&Watcher, Vec<Event>> = HashMap::new();
             for event in all_events {
-                let watchers: HashSet<&Arc<Watcher>> = watcher_map_r
+                let watch_ids = watcher_map_r
                     .index
                     .iter()
                     .filter_map(|(k, v)| {
@@ -294,8 +296,12 @@ where
                         .then_some(v)
                     })
                     .flatten()
-                    .collect();
-                for watcher in watchers {
+                    .collect_vec();
+                for watch_id in watch_ids {
+                    let watcher = watcher_map_r
+                        .watchers
+                        .get(watch_id)
+                        .unwrap_or_else(|| panic!("watcher index and watchers doesn't match"));
                     if event
                         .kv
                         .as_ref()

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -5,13 +5,18 @@ use std::{
         atomic::{AtomicI64, Ordering},
         Arc,
     },
+    time::Duration,
 };
 
 use clippy_utilities::OverflowArithmetic;
 use itertools::Itertools;
 use log::warn;
 use parking_lot::RwLock;
-use tokio::sync::mpsc;
+use tokio::{
+    sync::mpsc::{self, error::TrySendError},
+    time::sleep,
+};
+use tracing::debug;
 use utils::parking_lot_lock::RwLockMap;
 
 use super::storage_api::StorageApi;
@@ -47,6 +52,8 @@ struct Watcher {
     start_rev: i64,
     /// Event filters
     filters: Vec<i32>,
+    /// Stop notify
+    stop_notify: Arc<event_listener::Event>,
     /// Sender of watch event
     event_tx: mpsc::Sender<WatchEvent>,
 }
@@ -72,6 +79,7 @@ impl Watcher {
         watch_id: WatchId,
         start_rev: i64,
         filters: Vec<i32>,
+        stop_notify: Arc<event_listener::Event>,
         event_tx: mpsc::Sender<WatchEvent>,
     ) -> Self {
         Self {
@@ -79,6 +87,7 @@ impl Watcher {
             watch_id,
             start_rev,
             filters,
+            stop_notify,
             event_tx,
         }
     }
@@ -99,20 +108,55 @@ impl Watcher {
     }
 
     /// Notify events
-    fn notify(&self, (revision, mut events): (i64, Vec<Event>)) {
+    fn notify(
+        &mut self,
+        (revision, mut events): (i64, Vec<Event>),
+    ) -> Result<(), TrySendError<WatchEvent>> {
         if revision < self.start_rev() {
-            return;
+            return Ok(());
         }
-        events.retain(|event| self.filters.iter().all(|filter| filter != &event.r#type));
+        events.retain(|event| {
+            self.filters.iter().all(|filter| filter != &event.r#type)
+                && (event
+                    .kv
+                    .as_ref()
+                    .map_or(false, |kv| kv.mod_revision >= self.start_rev))
+        });
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        let watch_id = self.watch_id();
+        debug!(
+            watch_id,
+            revision,
+            events_len = events.len(),
+            "try to send watch response"
+        );
         let watch_event = WatchEvent {
-            id: self.watch_id(),
+            id: watch_id,
             events,
             revision,
         };
-        #[allow(clippy::todo)]
+
         match self.event_tx.try_send(watch_event) {
-            Ok(_) => {}
-            Err(_) => todo!(), // TODO: send error will move this watcher to victims
+            Ok(_) => {
+                debug!(watch_id, revision, "response sent successfully");
+                self.start_rev = revision.overflow_add(1);
+                Ok(())
+            }
+            Err(TrySendError::Closed(_)) => {
+                debug!(watch_id, revision, "watcher is closed");
+                self.stop_notify.notify(1);
+                Ok(())
+            }
+            Err(TrySendError::Full(watch_event)) => {
+                debug!(
+                    watch_id,
+                    revision, "events channel is full, will try to send later"
+                );
+                Err(TrySendError::Full(watch_event))
+            }
         }
     }
 }
@@ -126,63 +170,103 @@ where
     /// KV storage
     storage: Arc<KvStore<S>>,
     /// Watch indexes
-    watcher_map: RwLock<WatcherMap>,
+    watcher_map: Arc<RwLock<WatcherMap>>,
 }
 
 /// Store all watchers
 #[derive(Debug)]
 struct WatcherMap {
-    /// All watchers
-    watchers: HashMap<WatchId, Watcher>,
     /// Index for watchers
     index: HashMap<KeyRange, HashSet<WatchId>>,
+    /// All watchers
+    watchers: HashMap<WatchId, Watcher>,
+    /// Victims
+    victims: HashMap<Watcher, (i64, Vec<Event>)>,
 }
 
 impl WatcherMap {
     /// Create a new `WatcherMap`
     fn new() -> Self {
         Self {
-            watchers: HashMap::new(),
             index: HashMap::new(),
+            watchers: HashMap::new(),
+            victims: HashMap::new(),
         }
     }
 
     /// Insert a new watcher to the map and create. Internally, it will create a index for this watcher.
-    fn insert(&mut self, watcher: Watcher) {
+    fn register(&mut self, watcher: Watcher) {
         let key_range = watcher.key_range().clone();
         let watch_id = watcher.watch_id();
         assert!(
             self.watchers.insert(watch_id, watcher).is_none(),
-            "can't insert a watcher twice"
+            "can't insert a watcher to watchers twice"
         );
         assert!(
             self.index
                 .entry(key_range)
                 .or_insert_with(HashSet::new)
                 .insert(watch_id),
-            "can't insert a watcher twice"
+            "can't insert a watcher to index twice"
+        );
+    }
+
+    /// Move a watcher to victims, the `watch_id` must be valid.
+    fn move_to_victim(&mut self, watch_id: WatchId, updates: (i64, Vec<Event>)) {
+        debug!(watch_id, "move watcher to victim");
+        let Some(watcher) = self.watchers.remove(&watch_id) else {
+            unreachable!("watcher should exist")
+        };
+        let Some(watch_ids) = self.index.get_mut(watcher.key_range()) else {
+            unreachable!("watch_ids should exist")
+        };
+        assert!(
+            watch_ids.remove(&watcher.watch_id()),
+            "no such watcher in index"
+        );
+        if watch_ids.is_empty() {
+            assert!(
+                self.index.remove(&watcher.key_range).is_some(),
+                "watch_ids should exist"
+            );
+        }
+        let watch_event = WatchEvent {
+            id: watch_id,
+            revision: updates.0,
+            events: updates.1,
+        };
+        assert!(
+            self.victims
+                .insert(watcher, (watch_event.revision, watch_event.events))
+                .is_none(),
+            "can't insert a watcher to victims twice"
         );
     }
 
     /// Remove a watcher
-    #[allow(clippy::expect_used)] // the logic is managed internally
     fn remove(&mut self, watch_id: WatchId) {
-        let watcher = self.watchers.remove(&watch_id).expect("no such watcher");
-        let key_range = watcher.key_range();
-        let is_empty = {
-            let watchers = self
-                .index
-                .get_mut(key_range)
-                .expect("no such watcher in index");
-            assert!(
-                watchers.remove(&watcher.watch_id()),
-                "no such watcher in index"
-            );
-            watchers.is_empty()
+        if let Some(watcher) = self.watchers.remove(&watch_id) {
+            let key_range = watcher.key_range();
+            let is_empty = {
+                let Some(watch_ids) = self.index.get_mut(watcher.key_range()) else {
+                    unreachable!("watch_ids should exist")
+                };
+                assert!(
+                    watch_ids.remove(&watcher.watch_id()),
+                    "no such watcher in index"
+                );
+                watch_ids.is_empty()
+            };
+            if is_empty {
+                assert!(self.index.remove(key_range).is_some());
+            }
+        } else {
+            self.victims = self
+                .victims
+                .drain()
+                .filter(|pair| pair.0.watch_id() != watch_id)
+                .collect();
         };
-        if is_empty {
-            assert!(self.index.remove(key_range).is_some());
-        }
     }
 }
 
@@ -198,6 +282,7 @@ pub(crate) trait KvWatcherOps {
         key_range: KeyRange,
         start_rev: i64,
         filters: Vec<i32>,
+        stop_notify: Arc<event_listener::Event>,
         event_tx: mpsc::Sender<WatchEvent>,
     );
 
@@ -217,9 +302,17 @@ where
         key_range: KeyRange,
         start_rev: i64,
         filters: Vec<i32>,
+        stop_notify: Arc<event_listener::Event>,
         event_tx: mpsc::Sender<WatchEvent>,
     ) {
-        let mut watcher = Watcher::new(key_range.clone(), id, start_rev, filters, event_tx);
+        let mut watcher = Watcher::new(
+            key_range.clone(),
+            id,
+            start_rev,
+            filters,
+            stop_notify,
+            event_tx,
+        );
         let mut watcher_map_w = self.watcher_map.write();
 
         let initial_events = if start_rev == 0 {
@@ -233,18 +326,22 @@ where
                 })
         };
         if !initial_events.is_empty() {
-            let last_revision = initial_events
-                .last()
-                .unwrap_or_else(|| unreachable!("initial_events is not empty"))
-                .kv
-                .as_ref()
-                .unwrap_or_else(|| panic!("event.kv can't be None"))
-                .mod_revision;
-
-            watcher.notify((last_revision, initial_events));
-            watcher.start_rev = last_revision.overflow_add(1);
+            let last_revision = get_last_revision(&initial_events);
+            if let Err(TrySendError::Full(watch_event)) =
+                watcher.notify((last_revision, initial_events))
+            {
+                assert!(
+                    watcher_map_w
+                        .victims
+                        .insert(watcher, (watch_event.revision, watch_event.events))
+                        .is_none(),
+                    "can't insert a watcher to victims twice"
+                );
+                return;
+            };
         }
-        watcher_map_w.insert(watcher);
+        debug!("register watcher: {:?}", watcher);
+        watcher_map_w.register(watcher);
     }
 
     /// Cancel a watch from KV store
@@ -261,26 +358,90 @@ where
     pub(crate) fn new_arc(
         storage: Arc<KvStore<S>>,
         mut kv_update_rx: mpsc::Receiver<(i64, Vec<Event>)>,
+        shutdown_trigger: Arc<event_listener::Event>,
+        sync_victims_interval: Duration,
     ) -> Arc<Self> {
+        let watcher_map = Arc::new(RwLock::new(WatcherMap::new()));
         let kv_watcher = Arc::new(Self {
             storage,
-            watcher_map: RwLock::new(WatcherMap::new()),
+            watcher_map,
         });
-        let watcher = Arc::clone(&kv_watcher);
-        let _handle = tokio::spawn(async move {
-            while let Some(updates) = kv_update_rx.recv().await {
-                watcher.handle_kv_updates(updates);
+        let victim_handle =
+            tokio::spawn(Arc::clone(&kv_watcher).sync_victims_task(sync_victims_interval));
+        let kv_updates_handle = tokio::spawn({
+            let kv_watcher = Arc::clone(&kv_watcher);
+            async move {
+                while let Some(updates) = kv_update_rx.recv().await {
+                    kv_watcher.handle_kv_updates(updates);
+                }
             }
+        });
+        let _hd = tokio::spawn(async move {
+            shutdown_trigger.listen().await;
+            victim_handle.abort();
+            kv_updates_handle.abort();
         });
         kv_watcher
     }
 
+    /// Background task to sync victims
+    async fn sync_victims_task(self: Arc<Self>, sync_victims_interval: Duration) {
+        loop {
+            let victims = self
+                .watcher_map
+                .map_write(|mut m| m.victims.drain().collect::<Vec<_>>());
+            let mut new_victims = HashMap::new();
+            for (mut watcher, res) in victims {
+                if let Err(TrySendError::Full(watch_event)) = watcher.notify(res) {
+                    assert!(
+                        new_victims
+                            .insert(watcher, (watch_event.revision, watch_event.events))
+                            .is_none(),
+                        "can't insert a watcher to new_victims twice"
+                    );
+                } else {
+                    let mut watcher_map_w = self.watcher_map.write();
+                    let initial_events = self
+                        .storage
+                        .get_event_from_revision(watcher.key_range.clone(), watcher.start_rev)
+                        .unwrap_or_else(|e| {
+                            warn!("failed to get initial events for watcher: {:?}", e);
+                            vec![]
+                        });
+                    if !initial_events.is_empty() {
+                        let last_revision = get_last_revision(&initial_events);
+                        if let Err(TrySendError::Full(watch_event)) =
+                            watcher.notify((last_revision, initial_events))
+                        {
+                            assert!(
+                                new_victims
+                                    .insert(watcher, (watch_event.revision, watch_event.events))
+                                    .is_none(),
+                                "can't insert a watcher to new_victims twice"
+                            );
+                            break;
+                        };
+                    }
+                    debug!(
+                        watche_id = watcher.watch_id(),
+                        "watcher synced by sync_victims_task"
+                    );
+                    watcher_map_w.register(watcher);
+                }
+            }
+            if !new_victims.is_empty() {
+                self.watcher_map.write().victims.extend(new_victims);
+            }
+            sleep(sync_victims_interval).await;
+        }
+    }
+
     /// Handle KV store updates
     fn handle_kv_updates(&self, (revision, all_events): (i64, Vec<Event>)) {
-        self.watcher_map.map_read(|watcher_map_r| {
-            let mut watcher_events: HashMap<&Watcher, Vec<Event>> = HashMap::new();
+        self.watcher_map.map_write(|mut watcher_map_w| {
+            let mut watcher_events: HashMap<WatchId, Vec<Event>> = HashMap::new();
             for event in all_events {
-                let watch_ids = watcher_map_r
+                let watch_ids = watcher_map_w
                     .index
                     .iter()
                     .filter_map(|(k, v)| {
@@ -294,28 +455,24 @@ where
                         .then_some(v)
                     })
                     .flatten()
+                    .copied()
                     .collect_vec();
                 for watch_id in watch_ids {
-                    let watcher = watcher_map_r
-                        .watchers
-                        .get(watch_id)
-                        .unwrap_or_else(|| panic!("watcher index and watchers doesn't match"));
-                    if event
-                        .kv
-                        .as_ref()
-                        .map_or(true, |kv| kv.mod_revision < watcher.start_rev)
-                    {
-                        continue;
-                    }
-                    #[allow(clippy::indexing_slicing)]
                     watcher_events
-                        .entry(watcher)
+                        .entry(watch_id)
                         .or_default()
                         .push(event.clone());
                 }
             }
-            for (w, es) in watcher_events {
-                w.notify((revision, es));
+            for (watch_id, events) in watcher_events {
+                let watcher = watcher_map_w
+                    .watchers
+                    .get_mut(&watch_id)
+                    .unwrap_or_else(|| panic!("watcher index and watchers doesn't match"));
+                if let Err(TrySendError::Full(watch_event)) = watcher.notify((revision, events)) {
+                    watcher_map_w
+                        .move_to_victim(watch_id, (watch_event.revision, watch_event.events));
+                }
             }
         });
     }
@@ -349,12 +506,24 @@ impl WatchEvent {
     }
 }
 
+/// Get the last revision of a event slice
+fn get_last_revision(events: &[Event]) -> i64 {
+    events
+        .last()
+        .unwrap_or_else(|| unreachable!("events is not empty"))
+        .kv
+        .as_ref()
+        .unwrap_or_else(|| panic!("event.kv can't be None"))
+        .mod_revision
+}
+
 #[cfg(test)]
 mod test {
 
     use std::{collections::BTreeMap, time::Duration};
 
-    use tokio::time::timeout;
+    use clippy_utilities::Cast;
+    use tokio::time::{sleep, timeout};
     use utils::config::StorageConfig;
 
     use super::*;
@@ -377,7 +546,14 @@ mod test {
             Arc::clone(&db),
             index,
         ));
-        let kv_watcher = KvWatcher::new_arc(Arc::clone(&store), kv_update_rx);
+        let shutdown_trigger = Arc::new(event_listener::Event::new());
+        let sync_victims_interval = Duration::from_millis(10);
+        let kv_watcher = KvWatcher::new_arc(
+            Arc::clone(&store),
+            kv_update_rx,
+            shutdown_trigger,
+            sync_victims_interval,
+        );
         (store, db, kv_watcher)
     }
 
@@ -405,9 +581,17 @@ mod test {
                 }
             }
         });
-        tokio::time::sleep(std::time::Duration::from_micros(500)).await;
+        sleep(Duration::from_micros(500)).await;
         let (event_tx, mut event_rx) = mpsc::channel(128);
-        kv_watcher.watch(123, KeyRange::new_one_key("foo"), 1, vec![], event_tx);
+        let stop_notify = Arc::new(event_listener::Event::new());
+        kv_watcher.watch(
+            123,
+            KeyRange::new_one_key("foo"),
+            1,
+            vec![],
+            stop_notify,
+            event_tx,
+        );
 
         'outer: while let Some(event_batch) = timeout(Duration::from_secs(3), event_rx.recv())
             .await
@@ -415,6 +599,7 @@ mod test {
         {
             for event in event_batch.events {
                 let val = event.kv.as_ref().unwrap().value[0];
+                debug!(val, "receive event");
                 let e = map.entry(val).or_insert(0);
                 *e += 1;
                 if val == 99 {
@@ -428,5 +613,71 @@ mod test {
             assert_eq!(count, 1, "key {k} should be notified once");
         }
         handle.abort();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_victim() {
+        let (store, db, kv_watcher) = init_empty_store();
+        // response channel with capacity 1, so it will be full easily, then we can trigger victim
+        let (event_tx, mut event_rx) = mpsc::channel(1);
+        let stop_notify = Arc::new(event_listener::Event::new());
+
+        kv_watcher.watch(
+            123,
+            KeyRange::new_one_key("foo"),
+            0,
+            vec![],
+            stop_notify,
+            event_tx,
+        );
+
+        let mut expect = 0;
+        let handle = tokio::spawn(async move {
+            'outer: while let Some(watch_event) = event_rx.recv().await {
+                for event in watch_event.events {
+                    let val = event.kv.as_ref().unwrap().value[0];
+                    assert_eq!(val, expect);
+                    expect += 1;
+                    if val == 99 {
+                        break 'outer;
+                    }
+                }
+            }
+        });
+
+        for i in 0..100u8 {
+            let req = RequestWithToken::new(
+                PutRequest {
+                    key: "foo".into(),
+                    value: vec![i],
+                    ..Default::default()
+                }
+                .into(),
+            );
+            let (sync_res, ops) = store.after_sync(&req, i.cast()).await.unwrap();
+            db.flush_ops(ops).unwrap();
+            store.mark_index_available(sync_res.revision());
+        }
+        handle.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
+    async fn test_cancel_watcher() {
+        let (_store, _db, kv_watcher) = init_empty_store();
+        let (event_tx, _event_rx) = mpsc::channel(1);
+        let stop_notify = Arc::new(event_listener::Event::new());
+        kv_watcher.watch(
+            1,
+            KeyRange::new_one_key("foo"),
+            0,
+            vec![],
+            stop_notify,
+            event_tx,
+        );
+        assert!(!kv_watcher.watcher_map.read().index.is_empty());
+        assert!(!kv_watcher.watcher_map.read().watchers.is_empty());
+        kv_watcher.cancel(1);
+        assert!(kv_watcher.watcher_map.read().index.is_empty());
+        assert!(kv_watcher.watcher_map.read().watchers.is_empty());
     }
 }

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -202,7 +202,7 @@ pub(crate) trait KvWatcherOps {
     );
 
     /// Cancel a watch from KV store
-    fn cancel(&self, id: WatchId) -> i64;
+    fn cancel(&self, id: WatchId);
 }
 
 #[async_trait::async_trait]
@@ -248,10 +248,8 @@ where
     }
 
     /// Cancel a watch from KV store
-    fn cancel(&self, id: WatchId) -> i64 {
-        let revision = self.storage.revision();
-        self.watcher_map.write().remove(id);
-        revision
+    fn cancel(&self, watch_id: WatchId) {
+        self.watcher_map.write().remove(watch_id);
     }
 }
 

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -10,10 +10,7 @@ use tokio::{
     sync::broadcast::{self, Sender},
     time::{self, Duration},
 };
-use utils::config::{
-    default_range_retry_timeout, default_sync_victims_interval, ClientTimeout, CurpConfig,
-    StorageConfig,
-};
+use utils::config::{ClientTimeout, CurpConfig, ServerTimeout, StorageConfig};
 use xline::{client::Client, server::XlineServer, storage::db::DB};
 
 /// Cluster
@@ -89,8 +86,7 @@ impl Cluster {
                         ..Default::default()
                     },
                     ClientTimeout::default(),
-                    default_range_retry_timeout(),
-                    default_sync_victims_interval(),
+                    ServerTimeout::default(),
                     StorageConfig::Memory,
                     db,
                 )

--- a/xline/tests/common/mod.rs
+++ b/xline/tests/common/mod.rs
@@ -10,7 +10,10 @@ use tokio::{
     sync::broadcast::{self, Sender},
     time::{self, Duration},
 };
-use utils::config::{default_range_retry_timeout, ClientTimeout, CurpConfig, StorageConfig};
+use utils::config::{
+    default_range_retry_timeout, default_sync_victims_interval, ClientTimeout, CurpConfig,
+    StorageConfig,
+};
 use xline::{client::Client, server::XlineServer, storage::db::DB};
 
 /// Cluster
@@ -87,6 +90,7 @@ impl Cluster {
                     },
                     ClientTimeout::default(),
                     default_range_retry_timeout(),
+                    default_sync_victims_interval(),
                     StorageConfig::Memory,
                     db,
                 )


### PR DESCRIPTION
Please briefly answer these questions:
described in #253 
based on #262 
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
handle response channel block
* what changes does this pull request make?
add `sync_victims_task` to retry blocked response
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no