### PR TITLE
Refactor/watch prev kv

### DIFF
--- a/xline/src/rpc/mod.rs
+++ b/xline/src/rpc/mod.rs
@@ -475,6 +475,16 @@ impl RequestWithToken {
     }
 }
 
+impl Event {
+    pub(crate) fn is_create(&self) -> bool {
+        let kv = self
+            .kv
+            .as_ref()
+            .unwrap_or_else(|| panic!("kv must be Some"));
+        matches!(self.r#type(), EventType::Put) && kv.create_revision == kv.mod_revision
+    }
+}
+
 impl TxnRequest {
     /// Checks whether a given `TxnRequest` is read-only or not.
     fn is_read_only(&self) -> bool {

--- a/xline/src/storage/kv_store.rs
+++ b/xline/src/storage/kv_store.rs
@@ -376,6 +376,13 @@ where
         Ok((kvs, total))
     }
 
+    /// Get previous `KeyValue` of a `KeyValue`
+    pub(crate) fn get_prev_kv(&self, kv: &KeyValue) -> Option<KeyValue> {
+        self.get_range(&kv.key, &[], kv.mod_revision.overflow_sub(1))
+            .ok()?
+            .pop()
+    }
+
     /// Get `KeyValue` start from a revision and convert to `Event`
     pub(crate) fn get_event_from_revision(
         &self,


### PR DESCRIPTION
Please briefly answer these questions:
based on #268 
* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Handle prev_kv in watch
* what changes does this pull request make?
Reduce unnecessary io operations about prev_kv, and read it before notify when necessary
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
no