### PR TITLE
Copy curp integration tests to simulation package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,3 @@
 [workspace]
 
-members = ["xline", "curp", "benchmark", "utils", "engine"]
+members = ["xline", "curp", "benchmark", "utils", "engine", "simulation"]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/datenlord/Xline/tree/master/benchmark"
 
 [dependencies]
 xline = { path = "../xline" }
-tokio = "1.21.2"
+tokio = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tokio" }
 anyhow = "1.0.66"
 clap = { version = "3.2.16", features = ["derive"] }
 rand = "0.8.5"

--- a/curp/Cargo.toml
+++ b/curp/Cargo.toml
@@ -20,15 +20,25 @@ event-listener = "2.5.2"
 futures = "0.3.21"
 itertools = "0.10.3"
 utils = { path = "../utils", version = "0.1.0", features = ["parking_lot"] }
-madsim = { version = "0.2.0-alpha.3", features = ["rpc", "logger", "macros"] }
+madsim = { git = "https://github.com/bsbds/madsim.git", package = "madsim", features = ["rpc", "macros"] }
 opentelemetry = "0.18.0"
 parking_lot = "0.12.1"
-prost = "0.10.3"
+prost = "0.11"
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 thiserror = "1.0.31"
-tokio = { version = "1.19.0", features = ["rt-multi-thread"] }
-tokio-stream = { version = "0.1.9", features = ["net"] }
-tonic = "0.7.2"
+tokio = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tokio", features = [
+    "rt",
+    "rt-multi-thread",
+    "fs",
+    "sync",
+    "macros",
+    "time",
+    "signal",
+] }
+tokio-stream = { git = "https://github.com/madsim-rs/tokio.git", rev = "ab251ad", features = [
+  "net",
+] }
+tonic = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tonic" }
 tracing = { version = "0.1.34", features = ["std", "log", "attributes"] }
 tracing-opentelemetry = "0.18.0"
 flume = "0.10.14"
@@ -52,5 +62,5 @@ mockall = "0.11.3"
 once_cell = "1.17.0"
 
 [build-dependencies]
-tonic-build = "0.7.2"
-prost-build = "0.10.3"
+tonic-build = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tonic-build" }
+prost-build = "0.11"

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -20,11 +20,12 @@ serde = { version = "1.0.152", features = ["derive"] }
 bincode = "1.3.3"
 clippy-utilities = "0.2.0"
 async-trait = "0.1.67"
-tokio = { version = "1.26.0", features = [
-    "fs",
-    "macros",
+tokio = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tokio", features = [
+    "rt",
     "rt-multi-thread",
+    "fs",
     "io-util",
+    "macros",
 ] }
 bytes = "1.4.0"
 tokio-util = { version = "0.7.8", features = ["io"] }

--- a/simulation/Cargo.toml
+++ b/simulation/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "xline_simulation"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/simulation/Cargo.toml
+++ b/simulation/Cargo.toml
@@ -2,7 +2,41 @@
 name = "xline_simulation"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["DatenLord <dev@datenlord.io>"]
+categories = ["simulation"]
+description = "Madsim simulation for Xline"
+keywords = ["simulation"]
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/datenlord/Xline/tree/master/tests/simulation"
 
 [dependencies]
+curp = { path = "../curp" }
+utils = { path = "../utils", version = "0.1.0", features = ["parking_lot"] }
+engine = { path = "../engine" }
+thiserror = "1.0.31"
+async-trait = "0.1.53"
+madsim = { git = "https://github.com/bsbds/madsim.git", package = "madsim" }
+tokio = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tokio", features = [
+    "rt",
+    "rt-multi-thread",
+    "fs",
+    "sync",
+    "macros",
+    "time",
+    "signal",
+] }
+tonic = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tonic" }
+prost = "0.11"
+futures = "0.3.21"
+clippy-utilities = "0.2.0"
+itertools = "0.10.3"
+once_cell = "1.17.0"
+parking_lot = "0.12.1"
+serde = { version = "1.0.130", features = ["derive", "rc"] }
+tracing = { version = "0.1.34", features = ["std", "log", "attributes"] }
+bincode = "1.3.3"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter", "time"] }
+
+[build-dependencies]
+tonic-build = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tonic-build" }

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,0 +1,3 @@
+# xline_simulation
+
+This crate provides madsim simulation for Xline.

--- a/simulation/src/curp/curp_group.rs
+++ b/simulation/src/curp/curp_group.rs
@@ -1,0 +1,420 @@
+use std::{
+    collections::HashMap,
+    error::Error,
+    fmt::Display,
+    iter,
+    path::PathBuf,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    thread,
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use curp::{client::Client, server::Rpc, LogIndex, ProtocolServer, SnapshotAllocator, TxFilter};
+use engine::{Engine, EngineType, Snapshot};
+use futures::future::join_all;
+use itertools::Itertools;
+use parking_lot::Mutex;
+use tokio::{net::TcpListener, runtime::Runtime, sync::mpsc};
+use tokio_stream::wrappers::TcpListenerStream;
+use tracing::debug;
+use utils::config::{
+    default_candidate_timeout_ticks, default_cmd_workers, default_follower_timeout_ticks,
+    default_gc_interval, default_heartbeat_interval, default_retry_timeout, default_rpc_timeout,
+    default_server_wait_synced_timeout, ClientTimeout, CurpConfig, CurpConfigBuilder,
+};
+
+use crate::common::{
+    random_id,
+    test_cmd::{TestCE, TestCommand, TestCommandResult},
+};
+
+pub type ServerId = String;
+
+pub mod proto {
+    tonic::include_proto!("messagepb");
+}
+pub use proto::{protocol_client::ProtocolClient, ProposeRequest, ProposeResponse};
+
+use self::proto::{FetchLeaderRequest, FetchLeaderResponse};
+
+struct MemorySnapshotAllocator;
+
+#[async_trait]
+impl SnapshotAllocator for MemorySnapshotAllocator {
+    async fn allocate_new_snapshot(&self) -> Result<Snapshot, Box<dyn Error>> {
+        Ok(Snapshot::new_for_receiving(EngineType::Memory)?)
+    }
+}
+
+#[derive(Debug)]
+pub struct NotReachable;
+
+impl Display for NotReachable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Server not reachable")
+    }
+}
+
+impl Error for NotReachable {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        None
+    }
+}
+
+#[derive(Debug)]
+struct TestTxFilter {
+    reachable: Arc<AtomicBool>,
+}
+
+impl TestTxFilter {
+    fn new(reachable: Arc<AtomicBool>) -> Self {
+        Self { reachable }
+    }
+}
+
+impl TxFilter for TestTxFilter {
+    fn filter(&self) -> Option<()> {
+        self.reachable.load(Ordering::Acquire).then_some(())
+    }
+
+    fn boxed_clone(&self) -> Box<dyn TxFilter> {
+        Box::new(Self {
+            reachable: Arc::clone(&self.reachable),
+        })
+    }
+}
+
+pub struct CurpNode {
+    pub id: ServerId,
+    pub addr: String,
+    pub exe_rx: mpsc::UnboundedReceiver<(TestCommand, TestCommandResult)>,
+    pub as_rx: mpsc::UnboundedReceiver<(TestCommand, LogIndex)>,
+    pub store: Arc<Engine>,
+    pub rt: Runtime,
+    pub switch: Arc<AtomicBool>,
+    pub storage_path: String,
+}
+
+pub struct CrashedCurpNode {
+    pub id: ServerId,
+    pub addr: String,
+    pub storage_path: String,
+}
+
+pub struct CurpGroup {
+    pub nodes: HashMap<ServerId, CurpNode>,
+    pub crashed_nodes: HashMap<ServerId, CrashedCurpNode>,
+    pub all: HashMap<ServerId, String>,
+}
+
+impl CurpGroup {
+    pub async fn new(n_nodes: usize) -> Self {
+        assert!(n_nodes >= 3);
+        let listeners = join_all(
+            iter::repeat_with(|| async { TcpListener::bind("0.0.0.0:0").await.unwrap() })
+                .take(n_nodes),
+        )
+        .await;
+        let all = listeners
+            .iter()
+            .enumerate()
+            .map(|(i, listener)| (format!("S{i}"), listener.local_addr().unwrap().to_string()))
+            .collect_vec();
+
+        let nodes = listeners
+            .into_iter()
+            .enumerate()
+            .map(|(i, listener)| {
+                let id = format!("S{i}");
+                let addr = listener.local_addr().unwrap().to_string();
+                let storage_path = format!("/tmp/curp-{}", random_id());
+
+                let (exe_tx, exe_rx) = mpsc::unbounded_channel();
+                let (as_tx, as_rx) = mpsc::unbounded_channel();
+                let ce = TestCE::new(id.clone(), exe_tx, as_tx);
+                let store = Arc::clone(&ce.store);
+
+                let mut others = all.clone();
+                others.remove(i);
+
+                let rt = tokio::runtime::Builder::new_multi_thread()
+                    .worker_threads(2)
+                    .thread_name(format!("rt-{id}"))
+                    .enable_all()
+                    .build()
+                    .unwrap();
+                let handle = rt.handle().clone();
+
+                // create server switch
+                let switch = Arc::new(AtomicBool::new(true));
+                let switch_c = Arc::clone(&switch);
+                let reachable_layer = tower::filter::FilterLayer::new(move |req| {
+                    if switch_c.load(Ordering::Acquire) {
+                        Ok(req)
+                    } else {
+                        Err(NotReachable)
+                    }
+                });
+
+                let id_c = id.clone();
+                let switch_c = Arc::clone(&switch);
+                let storage_path_c = storage_path.clone();
+                thread::spawn(move || {
+                    handle.spawn(Rpc::run_from_listener(
+                        id_c,
+                        i == 0,
+                        others.into_iter().collect(),
+                        listener,
+                        ce,
+                        MemorySnapshotAllocator,
+                        Arc::new(
+                            CurpConfigBuilder::default()
+                                .data_dir(PathBuf::from(storage_path_c))
+                                .log_entries_cap(10)
+                                .build()
+                                .unwrap(),
+                        ),
+                        Some(Box::new(TestTxFilter::new(Arc::clone(&switch_c)))),
+                        Some(reachable_layer),
+                    ));
+                });
+
+                (
+                    id.clone(),
+                    CurpNode {
+                        id,
+                        addr,
+                        exe_rx,
+                        as_rx,
+                        store,
+                        rt,
+                        switch,
+                        storage_path,
+                    },
+                )
+            })
+            .collect();
+
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        debug!("successfully start group");
+        Self {
+            nodes,
+            all: all.into_iter().collect(),
+            crashed_nodes: HashMap::new(),
+        }
+    }
+
+    pub fn get_node(&self, id: &ServerId) -> &CurpNode {
+        &self.nodes[id]
+    }
+
+    pub async fn new_client(&self, timeout: ClientTimeout) -> Client<TestCommand> {
+        let addrs = self
+            .nodes
+            .iter()
+            .map(|(id, node)| (id.clone(), node.addr.clone()))
+            .collect();
+        Client::<TestCommand>::new(addrs, timeout).await
+    }
+
+    pub fn exe_rxs(
+        &mut self,
+    ) -> impl Iterator<Item = &mut mpsc::UnboundedReceiver<(TestCommand, TestCommandResult)>> {
+        self.nodes.values_mut().map(|node| &mut node.exe_rx)
+    }
+
+    pub fn as_rxs(
+        &mut self,
+    ) -> impl Iterator<Item = &mut mpsc::UnboundedReceiver<(TestCommand, LogIndex)>> {
+        self.nodes.values_mut().map(|node| &mut node.as_rx)
+    }
+
+    pub fn stop(mut self) {
+        let paths = self
+            .nodes
+            .values()
+            .map(|node| node.storage_path.clone())
+            .chain(
+                self.crashed_nodes
+                    .values()
+                    .map(|node| node.storage_path.clone()),
+            )
+            .collect_vec();
+        thread::spawn(move || {
+            self.nodes.clear();
+        })
+        .join()
+        .unwrap();
+        for path in paths {
+            std::fs::remove_dir_all(path).unwrap();
+        }
+    }
+
+    pub fn crash(&mut self, id: &ServerId) {
+        let node = self.nodes.remove(id).unwrap();
+        let crashed = CrashedCurpNode {
+            id: node.id.clone(),
+            addr: node.addr.clone(),
+            storage_path: node.storage_path.clone(),
+        };
+        self.crashed_nodes.insert(id.clone(), crashed);
+        thread::spawn(move || drop(node)).join().unwrap();
+    }
+
+    pub async fn restart(&mut self, id: &ServerId, is_leader: bool) {
+        let addr = self.all.get(id).unwrap().clone();
+        let listener = TcpListener::bind(&addr)
+            .await
+            .expect("can't restart because the original addr is taken");
+        let crashed = self.crashed_nodes.remove(id).expect("no such crashed node");
+
+        let (exe_tx, exe_rx) = mpsc::unbounded_channel();
+        let (as_tx, as_rx) = mpsc::unbounded_channel();
+        let ce = TestCE::new(id.clone(), exe_tx, as_tx);
+        let store = Arc::clone(&ce.store);
+
+        let mut others = self.all.clone();
+        others.remove(id);
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .thread_name(format!("rt-{id}"))
+            .enable_all()
+            .build()
+            .unwrap();
+        let handle = rt.handle().clone();
+
+        // create server switch
+        let switch = Arc::new(AtomicBool::new(true));
+        let switch_c = Arc::clone(&switch);
+        let reachable_layer = tower::filter::FilterLayer::new(move |req| {
+            if switch_c.load(Ordering::Relaxed) {
+                Ok(req)
+            } else {
+                Err(NotReachable)
+            }
+        });
+
+        let id_c = id.clone();
+        let switch_c = Arc::clone(&switch);
+        let storage_path = crashed.storage_path.clone();
+        thread::spawn(move || {
+            handle.spawn(Rpc::run_from_listener(
+                id_c,
+                is_leader,
+                others.into_iter().collect(),
+                listener,
+                ce,
+                MemorySnapshotAllocator,
+                Arc::new(
+                    CurpConfigBuilder::default()
+                        .data_dir(PathBuf::from(storage_path))
+                        .build()
+                        .unwrap(),
+                ),
+                Some(Box::new(TestTxFilter::new(Arc::clone(&switch_c)))),
+                Some(reachable_layer),
+            ));
+        });
+
+        let new_node = CurpNode {
+            id: id.clone(),
+            addr,
+            exe_rx,
+            as_rx,
+            store,
+            rt,
+            switch,
+            storage_path: crashed.storage_path,
+        };
+        self.nodes.insert(id.clone(), new_node);
+    }
+
+    pub async fn try_get_leader(&self) -> Option<(ServerId, u64)> {
+        let mut leader = None;
+        let mut max_term = 0;
+        for addr in self.all.values() {
+            let addr = format!("http://{}", addr);
+            let mut client = if let Ok(client) = ProtocolClient::connect(addr.clone()).await {
+                client
+            } else {
+                continue;
+            };
+
+            let FetchLeaderResponse { leader_id, term } =
+                if let Ok(resp) = client.fetch_leader(FetchLeaderRequest {}).await {
+                    resp.into_inner()
+                } else {
+                    continue;
+                };
+            if term > max_term {
+                max_term = term;
+                leader = leader_id;
+            } else if term == max_term && leader.is_none() {
+                leader = leader_id;
+            }
+        }
+        leader.map(|l| (l, max_term))
+    }
+
+    pub async fn get_leader(&self) -> (ServerId, u64) {
+        for _ in 0..5 {
+            if let Some(leader) = self.try_get_leader().await {
+                return leader;
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+        panic!("can't get leader");
+    }
+
+    // get latest term and ensure every working node has the same term
+    pub async fn get_term_checked(&self) -> u64 {
+        let mut max_term = None;
+        for addr in self.all.values() {
+            let addr = format!("http://{}", addr);
+            let mut client = if let Ok(client) = ProtocolClient::connect(addr.clone()).await {
+                client
+            } else {
+                continue;
+            };
+
+            let FetchLeaderResponse { leader_id, term } =
+                if let Ok(resp) = client.fetch_leader(FetchLeaderRequest {}).await {
+                    resp.into_inner()
+                } else {
+                    continue;
+                };
+
+            if let Some(max_term) = max_term {
+                assert_eq!(max_term, term);
+            } else {
+                max_term = Some(term);
+            }
+        }
+        max_term.unwrap()
+    }
+
+    pub fn disable_node(&self, id: &ServerId) {
+        let node = &self.nodes[id];
+        node.switch.store(false, Ordering::Relaxed);
+    }
+
+    pub fn enable_node(&self, id: &ServerId) {
+        let node = &self.nodes[id];
+        node.switch.store(true, Ordering::Relaxed);
+    }
+
+    pub async fn get_connect(&self, id: &ServerId) -> ProtocolClient<tonic::transport::Channel> {
+        let addr = self
+            .all
+            .iter()
+            .find_map(|(node_id, addr)| (node_id == id).then_some(addr))
+            .unwrap();
+        let addr = format!("http://{}", addr);
+        ProtocolClient::connect(addr.clone()).await.unwrap()
+    }
+}

--- a/simulation/src/curp/curp_group.rs
+++ b/simulation/src/curp/curp_group.rs
@@ -27,7 +27,7 @@ use utils::config::{
     default_server_wait_synced_timeout, ClientTimeout, CurpConfig, CurpConfigBuilder,
 };
 
-use crate::common::{
+use super::{
     random_id,
     test_cmd::{TestCE, TestCommand, TestCommandResult},
 };

--- a/simulation/src/curp/mod.rs
+++ b/simulation/src/curp/mod.rs
@@ -1,0 +1,40 @@
+#![allow(dead_code, unused)]
+
+use std::{env, io, time::Duration};
+
+use madsim::rand::{distributions::Alphanumeric, thread_rng, Rng};
+use thiserror::Error;
+use tracing_subscriber::fmt::time::{uptime, OffsetTime, Uptime};
+
+pub mod curp_group;
+pub mod test_cmd;
+
+pub const TEST_TABLE: &str = "test";
+pub const REVISION_TABLE: &str = "revision";
+
+pub fn init_logger() {
+    if env::var("RUST_LOG").is_err() {
+        env::set_var("RUST_LOG", "curp,server");
+    }
+    tracing_subscriber::fmt()
+        .with_timer(uptime())
+        .compact()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+}
+
+pub async fn sleep_millis(n: u64) {
+    tokio::time::sleep(Duration::from_millis(n)).await;
+}
+
+pub async fn sleep_secs(n: u64) {
+    tokio::time::sleep(Duration::from_secs(n)).await;
+}
+
+pub(crate) fn random_id() -> String {
+    thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(8)
+        .map(char::from)
+        .collect()
+}

--- a/simulation/src/curp/test_cmd.rs
+++ b/simulation/src/curp/test_cmd.rs
@@ -24,7 +24,7 @@ use thiserror::Error;
 use tokio::{sync::mpsc, time::sleep};
 use tracing::debug;
 
-use crate::common::{REVISION_TABLE, TEST_TABLE};
+use super::{REVISION_TABLE, TEST_TABLE};
 
 static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
 

--- a/simulation/src/curp/test_cmd.rs
+++ b/simulation/src/curp/test_cmd.rs
@@ -1,0 +1,314 @@
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    io::{self, Cursor, Read, SeekFrom, Write},
+    sync::{
+        atomic::{AtomicI64, AtomicU64, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use clippy_utilities::NumericCast;
+use curp::{
+    cmd::{Command, CommandExecutor, ConflictCheck, ProposeId},
+    LogIndex,
+};
+use engine::{Engine, EngineType, Snapshot, SnapshotApi, StorageEngine, WriteOperation};
+use itertools::Itertools;
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::{sync::mpsc, time::sleep};
+use tracing::debug;
+
+use crate::common::{REVISION_TABLE, TEST_TABLE};
+
+static NEXT_ID: Lazy<AtomicU64> = Lazy::new(|| AtomicU64::new(1));
+
+fn next_id() -> u64 {
+    NEXT_ID.fetch_add(1, Ordering::SeqCst)
+}
+
+#[derive(Error, Debug, Clone)]
+pub struct ExecuteError(String);
+
+impl Display for ExecuteError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub struct TestCommand {
+    id: ProposeId,
+    keys: Vec<u32>,
+    exe_dur: Duration,
+    as_dur: Duration,
+    exe_should_fail: bool,
+    as_should_fail: bool,
+    cmd_type: TestCommandType,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+pub enum TestCommandType {
+    Get,
+    Put(u32),
+}
+
+pub type TestCommandResult = (Vec<u32>, Vec<i64>);
+
+impl TestCommand {
+    pub fn new_get(keys: Vec<u32>) -> Self {
+        Self {
+            id: ProposeId::new(next_id().to_string()),
+            keys,
+            exe_dur: Duration::ZERO,
+            as_dur: Duration::ZERO,
+            exe_should_fail: false,
+            as_should_fail: false,
+            cmd_type: TestCommandType::Get,
+        }
+    }
+
+    pub fn new_put(keys: Vec<u32>, value: u32) -> Self {
+        Self {
+            id: ProposeId::new(next_id().to_string()),
+            keys,
+            exe_dur: Duration::ZERO,
+            as_dur: Duration::ZERO,
+            exe_should_fail: false,
+            as_should_fail: false,
+            cmd_type: TestCommandType::Put(value),
+        }
+    }
+
+    pub fn set_exe_dur(mut self, dur: Duration) -> Self {
+        self.exe_dur = dur;
+        self
+    }
+
+    pub fn set_as_dur(mut self, dur: Duration) -> Self {
+        self.as_dur = dur;
+        self
+    }
+
+    pub fn set_exe_should_fail(mut self) -> Self {
+        self.exe_should_fail = true;
+        self
+    }
+
+    pub fn set_asr_should_fail(mut self) -> Self {
+        self.as_should_fail = true;
+        self
+    }
+}
+
+impl Command for TestCommand {
+    type K = u32;
+
+    type PR = i64;
+
+    type ER = TestCommandResult;
+
+    type ASR = LogIndex;
+
+    fn keys(&self) -> &[Self::K] {
+        &self.keys
+    }
+
+    fn id(&self) -> &ProposeId {
+        &self.id
+    }
+}
+
+impl ConflictCheck for TestCommand {
+    fn is_conflict(&self, other: &Self) -> bool {
+        let this_keys = self.keys();
+        let other_keys = other.keys();
+
+        this_keys
+            .iter()
+            .cartesian_product(other_keys.iter())
+            .map(|(k1, k2)| k1.is_conflict(k2))
+            .any(|conflict| conflict)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TestCE {
+    server_id: String,
+    last_applied: Arc<AtomicU64>,
+    revision: Arc<AtomicI64>,
+    pub store: Arc<Engine>,
+    exe_sender: mpsc::UnboundedSender<(TestCommand, TestCommandResult)>,
+    after_sync_sender: mpsc::UnboundedSender<(TestCommand, LogIndex)>,
+}
+
+#[async_trait]
+impl CommandExecutor<TestCommand> for TestCE {
+    type Error = ExecuteError;
+
+    fn prepare(&self, cmd: &TestCommand) -> Result<<TestCommand as Command>::PR, Self::Error> {
+        let rev = if let TestCommandType::Put(_) = cmd.cmd_type {
+            self.revision.fetch_add(1, Ordering::Relaxed)
+        } else {
+            -1
+        };
+        Ok(rev)
+    }
+
+    async fn execute(
+        &self,
+        cmd: &TestCommand,
+    ) -> Result<<TestCommand as Command>::ER, Self::Error> {
+        sleep(cmd.exe_dur).await;
+        if cmd.exe_should_fail {
+            return Err(ExecuteError("fail".to_owned()));
+        }
+
+        debug!("{} execute cmd({})", self.server_id, cmd.id());
+
+        let keys = cmd
+            .keys
+            .iter()
+            .map(|k| k.to_be_bytes().to_vec())
+            .collect_vec();
+        let result: TestCommandResult = match cmd.cmd_type {
+            TestCommandType::Get => {
+                let value = self
+                    .store
+                    .get_multi(TEST_TABLE, &keys)
+                    .map_err(|e| ExecuteError(e.to_string()))?
+                    .into_iter()
+                    .flatten()
+                    .map(|v| u32::from_be_bytes(v.as_slice().try_into().unwrap()))
+                    .collect();
+                let revision = self
+                    .store
+                    .get_multi(REVISION_TABLE, &keys)
+                    .map_err(|e| ExecuteError(e.to_string()))?
+                    .into_iter()
+                    .flatten()
+                    .map(|v| i64::from_be_bytes(v.as_slice().try_into().unwrap()))
+                    .collect_vec();
+                (value, revision)
+            }
+            TestCommandType::Put(ref v) => {
+                let value = v.to_be_bytes().to_vec();
+                let wr_ops = keys
+                    .into_iter()
+                    .map(|key| WriteOperation::new_put(TEST_TABLE, key, value.clone()))
+                    .collect();
+                self.store
+                    .write_batch(wr_ops, true)
+                    .map_err(|e| ExecuteError(e.to_string()))?;
+                TestCommandResult::default()
+            }
+        };
+
+        self.exe_sender
+            .send((cmd.clone(), result.clone()))
+            .expect("failed to send exe msg");
+        Ok(result)
+    }
+
+    async fn after_sync(
+        &self,
+        cmd: &TestCommand,
+        index: LogIndex,
+        need_run: bool,
+        revision: Option<<TestCommand as Command>::PR>,
+    ) -> Result<<TestCommand as Command>::ASR, Self::Error> {
+        sleep(cmd.as_dur).await;
+        if cmd.as_should_fail {
+            return Err(ExecuteError("fail".to_owned()));
+        }
+        if need_run {
+            self.after_sync_sender
+                .send((cmd.clone(), index))
+                .expect("failed to send after sync msg");
+            if let TestCommandType::Put(_) = cmd.cmd_type {
+                let revision = revision.expect("revision should not be None");
+                debug!(
+                    "cmd {:?}-{} revision is {}",
+                    cmd.cmd_type,
+                    cmd.id(),
+                    revision
+                );
+                let wr_ops = cmd
+                    .keys
+                    .iter()
+                    .map(|key| {
+                        WriteOperation::new_put(
+                            REVISION_TABLE,
+                            key.to_be_bytes().to_vec(),
+                            revision.to_be_bytes().to_vec(),
+                        )
+                    })
+                    .collect();
+                self.store
+                    .write_batch(wr_ops, true)
+                    .map_err(|e| ExecuteError(e.to_string()))?;
+            }
+        }
+        self.last_applied.store(index, Ordering::Relaxed);
+        debug!(
+            "{} after sync cmd({:?} - {}), index: {index}",
+            self.server_id,
+            cmd.cmd_type,
+            cmd.id()
+        );
+        Ok(index)
+    }
+
+    fn last_applied(&self) -> Result<LogIndex, ExecuteError> {
+        Ok(self.last_applied.load(Ordering::Relaxed))
+    }
+
+    async fn snapshot(&self) -> Result<Snapshot, Self::Error> {
+        self.store
+            .get_snapshot("", &[TEST_TABLE])
+            .map_err(|e| ExecuteError(e.to_string()))
+    }
+
+    async fn reset(&self, snapshot: Option<(Snapshot, LogIndex)>) -> Result<(), Self::Error> {
+        let Some((mut snapshot, index)) = snapshot else {
+            self.last_applied.store(0, Ordering::Relaxed);
+            let ops = vec![WriteOperation::new_delete_range(TEST_TABLE, &[], &[0xff])];
+            self.store
+                .write_batch(ops, true)
+                .map_err(|e| ExecuteError(e.to_string()))?;
+            return Ok(());
+        };
+        self.last_applied
+            .store(index.numeric_cast(), Ordering::Relaxed);
+        snapshot.rewind().unwrap();
+        self.store
+            .apply_snapshot(snapshot, &[TEST_TABLE])
+            .await
+            .unwrap();
+        Ok(())
+    }
+}
+
+impl TestCE {
+    pub fn new(
+        server_id: String,
+        exe_sender: mpsc::UnboundedSender<(TestCommand, TestCommandResult)>,
+        after_sync_sender: mpsc::UnboundedSender<(TestCommand, LogIndex)>,
+    ) -> Self {
+        Self {
+            server_id,
+            last_applied: Arc::new(AtomicU64::new(0)),
+            revision: Arc::new(AtomicI64::new(1)),
+            store: Arc::new(
+                Engine::new(EngineType::Memory, &[TEST_TABLE, REVISION_TABLE]).unwrap(),
+            ),
+            exe_sender,
+            after_sync_sender,
+        }
+    }
+}

--- a/simulation/src/lib.rs
+++ b/simulation/src/lib.rs
@@ -1,0 +1,3 @@
+#![cfg(madsim)]
+
+pub mod curp;

--- a/simulation/tests/it/curp/mod.rs
+++ b/simulation/tests/it/curp/mod.rs
@@ -1,0 +1,4 @@
+mod read_state;
+mod server;
+mod server_election;
+mod server_recovery;

--- a/simulation/tests/it/curp/read_state.rs
+++ b/simulation/tests/it/curp/read_state.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+use curp::{client::ReadState, cmd::Command};
+use utils::config::ClientTimeout;
+
+use crate::common::{curp_group::CurpGroup, init_logger, sleep_millis, test_cmd::TestCommand};
+
+mod common;
+
+#[tokio::test]
+async fn read_state() {
+    init_logger();
+    let group = CurpGroup::new(3).await;
+    let put_client = group.new_client(ClientTimeout::default()).await;
+    let put_cmd = TestCommand::new_put(vec![0], 0).set_exe_dur(Duration::from_millis(100));
+    let put_id = put_cmd.id().clone();
+    tokio::spawn(async move {
+        assert_eq!(put_client.propose(put_cmd).await.unwrap().0, vec![]);
+    });
+    let get_client = group.new_client(ClientTimeout::default()).await;
+    let res = get_client
+        .fetch_read_state(&TestCommand::new_get(vec![0]))
+        .await
+        .unwrap();
+    if let ReadState::Ids(v) = res {
+        assert_eq!(v, vec![put_id])
+    } else {
+        unreachable!(
+            "expected result should be ReadState::Ids({:?}), but received {:?}",
+            vec![put_id],
+            res
+        );
+    }
+
+    sleep_millis(100).await;
+
+    let res = get_client
+        .fetch_read_state(&TestCommand::new_get(vec![0]))
+        .await
+        .unwrap();
+    if let ReadState::CommitIndex(index) = res {
+        assert_eq!(index, 1);
+    } else {
+        unreachable!(
+            "expected result should be ReadState::CommitIndex({:?}), but received {:?}",
+            1, res
+        );
+    }
+    group.stop();
+}

--- a/simulation/tests/it/curp/read_state.rs
+++ b/simulation/tests/it/curp/read_state.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 use curp::{client::ReadState, cmd::Command};
 use utils::config::ClientTimeout;
 
-use crate::common::{curp_group::CurpGroup, init_logger, sleep_millis, test_cmd::TestCommand};
-
-mod common;
+use crate::curp::{curp_group::CurpGroup, init_logger, sleep_millis, test_cmd::TestCommand};
 
 #[tokio::test]
 async fn read_state() {

--- a/simulation/tests/it/curp/server.rs
+++ b/simulation/tests/it/curp/server.rs
@@ -6,12 +6,11 @@ use clippy_utilities::NumericCast;
 use madsim::rand::{thread_rng, Rng};
 use utils::config::ClientTimeout;
 
-use crate::common::{
+use crate::curp::{
     curp_group::{proto::propose_response::ExeResult, CurpGroup, ProposeRequest, ProposeResponse},
     init_logger, sleep_millis, sleep_secs,
     test_cmd::TestCommand,
 };
-mod common;
 
 #[tokio::test]
 async fn basic_propose() {

--- a/simulation/tests/it/curp/server.rs
+++ b/simulation/tests/it/curp/server.rs
@@ -1,0 +1,227 @@
+//! Integration test for the curp server
+
+use std::{sync::Arc, time::Duration};
+
+use clippy_utilities::NumericCast;
+use madsim::rand::{thread_rng, Rng};
+use utils::config::ClientTimeout;
+
+use crate::common::{
+    curp_group::{proto::propose_response::ExeResult, CurpGroup, ProposeRequest, ProposeResponse},
+    init_logger, sleep_millis, sleep_secs,
+    test_cmd::TestCommand,
+};
+mod common;
+
+#[tokio::test]
+async fn basic_propose() {
+    init_logger();
+
+    let group = CurpGroup::new(3).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 0))
+            .await
+            .unwrap(),
+        (vec![], vec![])
+    );
+    assert_eq!(
+        client.propose(TestCommand::new_get(vec![0])).await.unwrap(),
+        (vec![0], vec![1])
+    );
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn synced_propose() {
+    init_logger();
+
+    let mut group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+    let cmd = TestCommand::new_get(vec![0]);
+
+    let (er, index) = client.propose_indexed(cmd.clone()).await.unwrap();
+    assert_eq!(er, (vec![], vec![]));
+    assert_eq!(index, 1); // log[0] is a fake one
+
+    for exe_rx in group.exe_rxs() {
+        let (cmd1, er) = exe_rx.recv().await.unwrap();
+        assert_eq!(cmd1, cmd);
+        assert_eq!(er, (vec![], vec![]));
+    }
+
+    for as_rx in group.as_rxs() {
+        let (cmd1, index) = as_rx.recv().await.unwrap();
+        assert_eq!(cmd1, cmd);
+        assert_eq!(index, 1);
+    }
+
+    group.stop();
+}
+
+// Each command should be executed once and only once on each node
+#[tokio::test]
+async fn exe_exact_n_times() {
+    init_logger();
+
+    let mut group = CurpGroup::new(3).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+    let cmd = TestCommand::new_get(vec![0]);
+
+    let er = client.propose(cmd.clone()).await.unwrap();
+    assert_eq!(er, (vec![], vec![]));
+
+    for exe_rx in group.exe_rxs() {
+        let (cmd1, er) = exe_rx.recv().await.unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), exe_rx.recv())
+                .await
+                .is_err()
+        );
+        assert_eq!(cmd1, cmd);
+        assert_eq!(er.0, vec![]);
+    }
+
+    for as_rx in group.as_rxs() {
+        let (cmd1, index) = as_rx.recv().await.unwrap();
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), as_rx.recv())
+                .await
+                .is_err()
+        );
+        assert_eq!(cmd1, cmd);
+        assert_eq!(index, 1);
+    }
+
+    group.stop();
+}
+
+// To verify PR #86 is fixed
+#[tokio::test]
+async fn fast_round_is_slower_than_slow_round() {
+    init_logger();
+
+    let group = CurpGroup::new(3).await;
+    let cmd = Arc::new(TestCommand::new_get(vec![0]));
+
+    let leader = group.get_leader().await.0;
+
+    // send propose only to the leader
+    let mut leader_connect = group.get_connect(&leader).await;
+    leader_connect
+        .propose(tonic::Request::new(ProposeRequest {
+            command: bincode::serialize(&cmd).unwrap(),
+        }))
+        .await
+        .unwrap();
+
+    // wait for the command to be synced to others
+    // because followers never get the cmd from the client, it will mark the cmd done in spec pool instead of removing the cmd from it
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // send propose to follower
+    let follower_addr = group.all.keys().find(|&id| &leader != id).unwrap();
+    let mut follower_connect = group.get_connect(follower_addr).await;
+
+    // the follower should response empty immediately
+    let resp: ProposeResponse = follower_connect
+        .propose(tonic::Request::new(ProposeRequest {
+            command: bincode::serialize(&cmd).unwrap(),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(resp.exe_result.is_none());
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn concurrent_cmd_order() {
+    init_logger();
+
+    let cmd0 = TestCommand::new_put(vec![0], 0).set_exe_dur(Duration::from_secs(1));
+    let cmd1 = TestCommand::new_put(vec![0, 1], 1);
+    let cmd2 = TestCommand::new_put(vec![1], 2);
+
+    let group = CurpGroup::new(3).await;
+    let leader = group.get_leader().await.0;
+    let mut leader_connect = group.get_connect(&leader).await;
+
+    let mut c = leader_connect.clone();
+    tokio::spawn(async move {
+        c.propose(ProposeRequest {
+            command: bincode::serialize(&cmd0).unwrap(),
+        })
+        .await
+        .expect("propose failed");
+    });
+
+    sleep_millis(20).await;
+    let response = leader_connect
+        .propose(ProposeRequest {
+            command: bincode::serialize(&cmd1).unwrap(),
+        })
+        .await
+        .expect("propose failed")
+        .into_inner();
+    assert!(matches!(response.exe_result.unwrap(), ExeResult::Error(_)));
+    let response = leader_connect
+        .propose(ProposeRequest {
+            command: bincode::serialize(&cmd2).unwrap(),
+        })
+        .await
+        .expect("propose failed")
+        .into_inner();
+    assert!(matches!(response.exe_result.unwrap(), ExeResult::Error(_)));
+
+    sleep_secs(1).await;
+
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![1]))
+            .await
+            .unwrap()
+            .0,
+        vec![2]
+    );
+
+    group.stop();
+}
+
+/// This test case ensures that the issue 228 is fixed.
+#[tokio::test]
+async fn concurrent_cmd_order_should_have_correct_revision() {
+    init_logger();
+
+    let group = CurpGroup::new(3).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    let sample_range = 1..=1000;
+
+    for i in sample_range.clone() {
+        let rand_dur = Duration::from_millis(thread_rng().gen_range(0..500).numeric_cast());
+        let _er = client
+            .propose(TestCommand::new_put(vec![i], i).set_as_dur(rand_dur))
+            .await
+            .unwrap();
+    }
+
+    for i in sample_range {
+        assert_eq!(
+            client
+                .propose(TestCommand::new_get(vec![i]))
+                .await
+                .unwrap()
+                .1,
+            vec![i.numeric_cast::<i64>()]
+        )
+    }
+
+    group.stop();
+}

--- a/simulation/tests/it/curp/server_election.rs
+++ b/simulation/tests/it/curp/server_election.rs
@@ -3,9 +3,7 @@ use std::time::Duration;
 use madsim::time::sleep;
 use utils::config::ClientTimeout;
 
-use crate::common::{curp_group::CurpGroup, init_logger, test_cmd::TestCommand};
-
-mod common;
+use crate::curp::{curp_group::CurpGroup, init_logger, test_cmd::TestCommand};
 
 async fn wait_for_election() {
     sleep(Duration::from_secs(3)).await;

--- a/simulation/tests/it/curp/server_election.rs
+++ b/simulation/tests/it/curp/server_election.rs
@@ -1,0 +1,131 @@
+use std::time::Duration;
+
+use madsim::time::sleep;
+use utils::config::ClientTimeout;
+
+use crate::common::{curp_group::CurpGroup, init_logger, test_cmd::TestCommand};
+
+mod common;
+
+async fn wait_for_election() {
+    sleep(Duration::from_secs(3)).await;
+}
+
+// Election
+#[tokio::test]
+async fn election() {
+    init_logger();
+
+    let group = CurpGroup::new(5).await;
+    let leader0 = group.get_leader().await.0;
+    group.disable_node(&leader0);
+    wait_for_election().await;
+
+    // check whether there is exact one leader in the group
+    let leader1 = group.get_leader().await.0;
+    let term1 = group.get_term_checked().await;
+
+    // check after some time, the term and the leader is still not changed
+    tokio::time::sleep(Duration::from_secs(1)).await;
+    let leader2 = group
+        .try_get_leader()
+        .await
+        .expect("There should be one leader")
+        .0;
+    let term2 = group.get_term_checked().await;
+
+    assert_ne!(leader0, leader1);
+    assert_eq!(term1, term2);
+    assert_eq!(leader1, leader2);
+
+    group.stop();
+}
+
+// Reelect after network failure
+#[tokio::test]
+async fn reelect() {
+    init_logger();
+
+    let group = CurpGroup::new(5).await;
+
+    // check whether there is exact one leader in the group
+    let leader1 = group.get_leader().await.0;
+    let term1 = group.get_term_checked().await;
+
+    // disable leader 1
+    group.disable_node(&leader1);
+    println!("disable leader {leader1}");
+
+    // after some time, a new leader should be elected
+    wait_for_election().await;
+    let (leader2, term2) = group.get_leader().await;
+
+    assert_ne!(term1, term2);
+    assert_ne!(leader1, leader2);
+
+    // disable leader 2
+    group.disable_node(&leader2);
+    println!("disable leader {leader2}");
+
+    // after some time, a new leader should be elected
+    wait_for_election().await;
+    let (leader3, term3) = group.get_leader().await;
+
+    assert_ne!(term1, term3);
+    assert_ne!(term2, term3);
+    assert_ne!(leader1, leader3);
+    assert_ne!(leader2, leader3);
+
+    // disable leader 3
+    group.disable_node(&leader3);
+    println!("disable leader {leader3}");
+
+    // after some time, no leader should be elected
+    wait_for_election().await;
+    assert!(group.try_get_leader().await.is_none());
+
+    // recover network partition
+    println!("enable all");
+    group.enable_node(&leader1);
+    group.enable_node(&leader2);
+    group.enable_node(&leader3);
+
+    wait_for_election().await;
+    let (_, final_term) = group.get_leader().await;
+    assert!(final_term > term3);
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn propose_after_reelect() {
+    init_logger();
+
+    let group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 0))
+            .await
+            .unwrap()
+            .0,
+        vec![]
+    );
+    // wait for the cmd to be synced
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let leader1 = group.get_leader().await.0;
+    group.disable_node(&leader1);
+
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    group.stop();
+}

--- a/simulation/tests/it/curp/server_recovery.rs
+++ b/simulation/tests/it/curp/server_recovery.rs
@@ -1,0 +1,454 @@
+//! Integration test for the curp server
+
+use std::{sync::Arc, time::Duration};
+
+use engine::StorageEngine;
+use itertools::Itertools;
+use tracing::debug;
+use utils::config::ClientTimeout;
+
+use crate::common::{
+    curp_group::{CurpGroup, ProposeRequest},
+    init_logger, sleep_millis, sleep_secs,
+    test_cmd::TestCommand,
+    TEST_TABLE,
+};
+
+mod common;
+
+#[tokio::test]
+async fn leader_crash_and_recovery() {
+    init_logger();
+
+    let mut group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    let leader = group.try_get_leader().await.unwrap().0;
+    group.crash(&leader);
+
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 0))
+            .await
+            .unwrap()
+            .0,
+        vec![]
+    );
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    // restart the original leader
+    sleep_secs(3).await;
+    group.restart(&leader, false).await;
+    let old_leader = group.nodes.get_mut(&leader).unwrap();
+
+    let (_cmd, er) = old_leader.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![]);
+    let asr = old_leader.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 1);
+
+    let (_cmd, er) = old_leader.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![0]);
+    let asr = old_leader.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 2);
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn follower_crash_and_recovery() {
+    init_logger();
+
+    let mut group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    let leader = group.try_get_leader().await.unwrap().0;
+    let follower = group
+        .nodes
+        .keys()
+        .find(|&id| id != &leader)
+        .unwrap()
+        .clone();
+    group.crash(&follower);
+
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 0))
+            .await
+            .unwrap()
+            .0,
+        vec![]
+    );
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    // let cmds to be synced
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // restart follower
+    group.restart(&follower, false).await;
+    let follower = group.nodes.get_mut(&follower).unwrap();
+
+    let (_cmd, er) = follower.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![]);
+    let asr = follower.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 1);
+
+    let (_cmd, er) = follower.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![0]);
+    let asr = follower.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 2);
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn leader_and_follower_both_crash_and_recovery() {
+    init_logger();
+
+    let mut group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    let leader = group.try_get_leader().await.unwrap().0;
+    let follower = group
+        .nodes
+        .keys()
+        .find(|&id| id != &leader)
+        .unwrap()
+        .clone();
+    group.crash(&follower);
+
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 0))
+            .await
+            .unwrap()
+            .0,
+        vec![]
+    );
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    // let cmds to be synced
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    group.crash(&leader);
+
+    // restart the original leader
+    group.restart(&leader, false).await;
+    // add a new log to commit previous logs
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+    let old_leader = group.nodes.get_mut(&leader).unwrap();
+
+    let (_cmd, er) = old_leader.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![]);
+    let asr = old_leader.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 1);
+
+    let (_cmd, er) = old_leader.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![0]);
+    let asr = old_leader.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 2);
+
+    // restart follower
+    group.restart(&follower, false).await;
+    let follower = group.nodes.get_mut(&follower).unwrap();
+
+    let (_cmd, er) = follower.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![]);
+    let asr = follower.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 1);
+
+    let (_cmd, er) = follower.exe_rx.recv().await.unwrap();
+    assert_eq!(er.0, vec![0]);
+    let asr = follower.as_rx.recv().await.unwrap();
+    assert_eq!(asr.1, 2);
+
+    group.stop();
+}
+
+// Leader should recover speculatively executed commands
+#[tokio::test]
+async fn new_leader_will_recover_spec_cmds_cond1() {
+    init_logger();
+
+    let mut group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    let leader1 = group.get_leader().await.0;
+
+    // 1: send cmd1 to all others except the leader
+    let cmd1 = Arc::new(TestCommand::new_put(vec![0], 0));
+    let req1 = ProposeRequest {
+        command: bincode::serialize(&cmd1).unwrap(),
+    };
+    for id in group.all.keys().filter(|&id| id != &leader1).take(4) {
+        let mut connect = group.get_connect(id).await;
+        connect.propose(req1.clone()).await.unwrap();
+    }
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // 2: disable leader1
+    group.disable_node(&leader1);
+
+    // 3: the client should automatically find the new leader and get the response
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    // old leader should recover from the new leader
+    group.enable_node(&leader1);
+
+    // every cmd should be executed and after synced on every node
+    for rx in group.exe_rxs() {
+        rx.recv().await;
+        rx.recv().await;
+    }
+    for rx in group.as_rxs() {
+        rx.recv().await;
+        rx.recv().await;
+    }
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn new_leader_will_recover_spec_cmds_cond2() {
+    init_logger();
+
+    let group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    let leader1 = group.get_leader().await.0;
+
+    // 1: disable leader1
+    group.disable_node(&leader1);
+
+    // now when the client proposes, all others will receive the proposal.
+    // but since a new round of election has not started yet, none of them will execute them
+    // when a new leader is elected, the cmd will be recovered(because it has been replicated on all others)
+    // now the client will resend the proposal to the new leader, asking it to sync again(the leader could have already completed sync or is syncing)
+    // the new leader should return empty, asking the client to fall back to wait synced
+
+    // 2: the client should automatically find the new leader and get the response
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 0))
+            .await
+            .unwrap()
+            .0,
+        vec![]
+    );
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    group.stop();
+}
+
+// Old Leader should discard spec states
+#[tokio::test]
+async fn old_leader_will_discard_spec_exe_cmds() {
+    init_logger();
+
+    let group = CurpGroup::new(5).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    // 0: let's first propose an initial cmd0
+    let cmd0 = TestCommand::new_put(vec![0], 0);
+    let (er, index) = client.propose_indexed(cmd0).await.unwrap();
+    assert_eq!(er.0, vec![]);
+    assert_eq!(index, 1);
+    sleep_secs(1).await;
+
+    // 1: disable all others to prevent the cmd1 to be synced
+    let leader1 = group.get_leader().await.0;
+    for node in group.nodes.values().filter(|node| node.id != leader1) {
+        group.disable_node(&node.id);
+    }
+
+    // 2: send the cmd1 to the leader, it should be speculatively executed
+    let cmd1 = Arc::new(TestCommand::new_put(vec![0], 1));
+    let req1 = ProposeRequest {
+        command: bincode::serialize(&cmd1).unwrap(),
+    };
+    let mut leader1_connect = group.get_connect(&leader1).await;
+    leader1_connect.propose(req1).await.unwrap();
+    sleep_millis(100).await;
+    let leader1_store = Arc::clone(&group.get_node(&leader1).store);
+    let res = leader1_store.get_all(TEST_TABLE).unwrap();
+    assert_eq!(
+        res,
+        vec![(0u32.to_be_bytes().to_vec(), 1u32.to_be_bytes().to_vec())]
+    );
+
+    // 3: recover all others and disable leader, a new leader will be elected
+    group.disable_node(&leader1);
+    sleep_millis(100).await;
+    for node in group.nodes.values().filter(|node| node.id != leader1) {
+        group.enable_node(&node.id);
+    }
+    sleep_secs(3).await;
+    let leader2 = group.get_leader().await.0;
+    assert_ne!(leader2, leader1);
+
+    // 4: recover the old leader, its state should be reverted to the original state
+    group.enable_node(&leader1);
+    sleep_secs(1).await;
+    let res = leader1_store.get_all(TEST_TABLE).unwrap();
+    assert_eq!(
+        res,
+        vec![(0u32.to_be_bytes().to_vec(), 0u32.to_be_bytes().to_vec())]
+    );
+
+    // 5: the client should also get the original state
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn all_crash_and_recovery() {
+    init_logger();
+
+    let mut group = CurpGroup::new(3).await;
+    let client = group.new_client(ClientTimeout::default()).await;
+
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 0))
+            .await
+            .unwrap()
+            .0,
+        vec![]
+    );
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+
+    let all = group.all.keys().cloned().collect_vec();
+    for node in &all {
+        group.crash(node);
+    }
+    sleep_secs(2).await;
+    for node in &all {
+        group.restart(node, node.as_str() == "S0").await;
+    }
+
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![0]
+    );
+    assert_eq!(
+        client
+            .propose(TestCommand::new_put(vec![0], 1))
+            .await
+            .unwrap()
+            .0,
+        vec![]
+    );
+    assert_eq!(
+        client
+            .propose(TestCommand::new_get(vec![0]))
+            .await
+            .unwrap()
+            .0,
+        vec![1]
+    );
+
+    group.stop();
+}
+
+#[tokio::test]
+async fn recovery_after_compaction() {
+    init_logger();
+
+    let mut group = CurpGroup::new(5).await;
+    let client = group.new_client(Default::default()).await;
+    let (leader, _term) = group.get_leader().await;
+    let node_id = group
+        .nodes
+        .keys()
+        .find(|&n| n != &leader)
+        .unwrap()
+        .to_owned();
+    group.crash(&node_id);
+
+    // since the log entries cap is set to 10, 50 commands will trigger log compactions
+    for i in 0..50 {
+        assert!(client
+            .propose(TestCommand::new_put(vec![i], i))
+            .await
+            .is_ok());
+    }
+
+    sleep_secs(1).await;
+
+    debug!("start recovery");
+
+    // the restarted node should use snapshot to recover
+    group.restart(&node_id, false).await;
+
+    sleep_secs(3).await;
+
+    {
+        let node = group.nodes.get_mut(&node_id).unwrap();
+        for i in 0..50_u32 {
+            let kv = i.to_be_bytes().to_vec();
+            let val = node.store.get(TEST_TABLE, &kv).unwrap().unwrap();
+            assert_eq!(val, kv);
+        }
+    }
+
+    group.stop();
+}

--- a/simulation/tests/it/curp/server_recovery.rs
+++ b/simulation/tests/it/curp/server_recovery.rs
@@ -14,8 +14,6 @@ use crate::common::{
     TEST_TABLE,
 };
 
-mod common;
-
 #[tokio::test]
 async fn leader_crash_and_recovery() {
     init_logger();

--- a/simulation/tests/it/main.rs
+++ b/simulation/tests/it/main.rs
@@ -1,0 +1,3 @@
+#![cfg(madsim)]
+
+mod curp;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -20,13 +20,14 @@ parking_lot = ["dep:parking_lot"]
 
 [dependencies]
 parking_lot = { version = "0.12.1", optional = true }
-tokio = { version = "1.23.0", features = [
+tokio = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tokio", features = [
+    "rt",
+    "rt-multi-thread",
     "sync",
     "macros",
-    "rt-multi-thread",
 ], optional = true }
 async-trait = { version = "0.1.60", optional = true }
-tonic = "0.7.2"
+tonic = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tonic" }
 opentelemetry = "0.18.0"
 tracing = "0.1.37"
 tracing-opentelemetry = "0.18.0"

--- a/xline/Cargo.toml
+++ b/xline/Cargo.toml
@@ -34,18 +34,21 @@ opentelemetry-contrib = { version = "0.10.0", features = [
 opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio"] }
 parking_lot = "0.12.0"
 pbkdf2 = { version = "0.11.0", features = ["std"] }
-prost = "0.10.3"
+prost = "0.11"
 serde = { version = "1.0.137", features = ["derive"] }
 thiserror = "1.0.37"
-tokio = { version = "1.0", features = [
+tokio = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tokio", features = [
+    "rt",
     "rt-multi-thread",
-    "time",
     "fs",
+    "sync",
     "macros",
-    "net",
+    "time",
 ] }
-tokio-stream = { version = "0.1.9", features = ["net"] }
-tonic = "0.7.2"
+tokio-stream = { git = "https://github.com/madsim-rs/tokio.git", rev = "ab251ad", features = [
+  "net",
+] }
+tonic = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tonic" }
 tracing = "0.1.37"
 tracing-opentelemetry = "0.18.0"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
@@ -62,7 +65,7 @@ bytes = "1.4.0"
 tokio-util = { version = "0.7.8", features = ["io"] }
 
 [build-dependencies]
-tonic-build = "0.7.2"
+tonic-build = { git = "https://github.com/bsbds/madsim.git", package = "madsim-tonic-build" }
 
 [dev-dependencies]
 mockall = "0.11.3"


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

  Prepare for creating new simulation test for madsim.

* what changes does this pull request make?

  Copy the orginal curp integration tests to the `simulation` package and update necessary dependencies.

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)

  No.