### PR TITLE
Reafactor/read state

### DIFF
--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -62,7 +62,7 @@ pub trait Command:
         &self,
         e: &E,
         index: LogIndex,
-        prepare_res: Option<Self::PR>,
+        prepare_res: Self::PR,
     ) -> Result<Self::ASR, E::Error>
     where
         E: CommandExecutor<Self> + Send + Sync,
@@ -137,7 +137,7 @@ where
         &self,
         cmd: &C,
         index: LogIndex,
-        prepare_res: Option<C::PR>,
+        prepare_res: C::PR,
     ) -> Result<C::ASR, Self::Error>;
 
     /// Index of the last log entry that has been successfully applied to the command executor

--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -62,13 +62,12 @@ pub trait Command:
         &self,
         e: &E,
         index: LogIndex,
-        need_run: bool,
-        prepare_res: Option<Self::PR>, // TODO: remove `need_run` and the option wrapper when issue 270 is closed
+        prepare_res: Option<Self::PR>,
     ) -> Result<Self::ASR, E::Error>
     where
         E: CommandExecutor<Self> + Send + Sync,
     {
-        <E as CommandExecutor<Self>>::after_sync(e, self, index, need_run, prepare_res).await
+        <E as CommandExecutor<Self>>::after_sync(e, self, index, prepare_res).await
     }
 }
 
@@ -138,8 +137,7 @@ where
         &self,
         cmd: &C,
         index: LogIndex,
-        need_run: bool,
-        prepare_res: Option<C::PR>, // TODO: remove `need_run` and the option wrapper when issue 270 is closed
+        prepare_res: Option<C::PR>,
     ) -> Result<C::ASR, Self::Error>;
 
     /// Index of the last log entry that has been successfully applied to the command executor

--- a/curp/src/cmd.rs
+++ b/curp/src/cmd.rs
@@ -40,20 +40,20 @@ pub trait Command:
 
     /// Prepare the command
     #[inline]
-    fn prepare<E>(&self, e: &E) -> Result<Self::PR, E::Error>
+    fn prepare<E>(&self, e: &E, index: LogIndex) -> Result<Self::PR, E::Error>
     where
         E: CommandExecutor<Self> + Send + Sync,
     {
-        <E as CommandExecutor<Self>>::prepare(e, self)
+        <E as CommandExecutor<Self>>::prepare(e, self, index)
     }
 
     /// Execute the command according to the executor
     #[inline]
-    async fn execute<E>(&self, e: &E) -> Result<Self::ER, E::Error>
+    async fn execute<E>(&self, e: &E, index: LogIndex) -> Result<Self::ER, E::Error>
     where
         E: CommandExecutor<Self> + Send + Sync,
     {
-        <E as CommandExecutor<Self>>::execute(e, self).await
+        <E as CommandExecutor<Self>>::execute(e, self, index).await
     }
 
     /// Execute the command after_sync callback
@@ -128,10 +128,10 @@ where
     type Error: std::fmt::Debug + Send + Sync + Clone + std::error::Error;
 
     /// Prepare the command
-    fn prepare(&self, cmd: &C) -> Result<C::PR, Self::Error>;
+    fn prepare(&self, cmd: &C, index: LogIndex) -> Result<C::PR, Self::Error>;
 
     /// Execute the command
-    async fn execute(&self, cmd: &C) -> Result<C::ER, Self::Error>;
+    async fn execute(&self, cmd: &C, index: LogIndex) -> Result<C::ER, Self::Error>;
 
     /// Execute the after_sync callback
     async fn after_sync(

--- a/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
+++ b/curp/src/server/cmd_worker/conflict_checked_mpmc.rs
@@ -59,7 +59,7 @@ pub(super) enum TaskType<C: Command> {
     /// Execute a cmd
     SpecExe(Arc<C>, LogIndex, Option<String>),
     /// After sync a cmd
-    AS(Arc<C>, LogIndex, Option<C::PR>),
+    AS(Arc<C>, LogIndex, C::PR),
     /// Reset the CE
     Reset(Option<Snapshot>, oneshot::Sender<()>),
     /// Snapshot
@@ -345,6 +345,9 @@ impl<C: Command, CE: CommandExecutor<C>> Filter<C, CE> {
                 }
                 (ExeState::Executed(true), AsState::AfterSyncReady(index, prepare)) => {
                     *as_st = AsState::AfterSyncing;
+                    let Some(prepare) = prepare else {
+                        unreachable!("prepare always exists when exe_state is Executed(true)");
+                    };
                     let task = Task {
                         vid,
                         inner: Cart::new(TaskType::AS(Arc::clone(cmd), index, prepare)),

--- a/curp/src/server/cmd_worker/mod.rs
+++ b/curp/src/server/cmd_worker/mod.rs
@@ -86,19 +86,12 @@ async fn cmd_worker<C: Command + 'static, CE: 'static + CommandExecutor<C>>(
                 }
             }
             TaskType::AS(ref cmd, index, prepare) => {
-                let need_run = cb
-                    .read()
-                    .er_buffer
-                    .get(cmd.id())
-                    .map_or(false, Result::is_ok);
                 let asr = ce
-                    .after_sync(cmd.as_ref(), index, need_run, prepare)
+                    .after_sync(cmd.as_ref(), index, prepare)
                     .await
                     .map_err(|e| e.to_string());
                 let asr_ok = asr.is_ok();
-                if need_run {
-                    cb.write().insert_asr(cmd.id(), asr);
-                }
+                cb.write().insert_asr(cmd.id(), asr);
                 sp.lock().remove(cmd.id());
                 let _ig = ucp.lock().remove(cmd.id());
                 debug!("{id} cmd({}) after sync is called", cmd.id());

--- a/curp/src/server/raw_curp/mod.rs
+++ b/curp/src/server/raw_curp/mod.rs
@@ -247,7 +247,7 @@ impl<C: 'static + Command> RawCurp<C> {
 
         if !conflict {
             log_w.last_exe = index;
-            self.ctx.cmd_tx.send_sp_exe(cmd);
+            self.ctx.cmd_tx.send_sp_exe(cmd, index);
         }
 
         self.ctx.sync_events.iter().for_each(|(id, event)| {
@@ -280,7 +280,7 @@ impl<C: 'static + Command> RawCurp<C> {
         leader_commit: LogIndex,
     ) -> Result<u64, (u64, LogIndex)> {
         debug!(
-            "{} received append_entries from {}: term({}), commit({}), prev_log_index({}), prev_log_term({}), {} entries", 
+            "{} received append_entries from {}: term({}), commit({}), prev_log_index({}), prev_log_term({}), {} entries",
             self.id(), leader_id, term, leader_commit, prev_log_index, prev_log_term, entries.len()
         );
 

--- a/curp/src/server/raw_curp/tests.rs
+++ b/curp/src/server/raw_curp/tests.rs
@@ -66,7 +66,7 @@ impl<C: 'static + Command> RawCurp<C> {
 fn leader_handle_propose_will_succeed() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
-        exe_tx.expect_send_sp_exe().returning(|_| {});
+        exe_tx.expect_send_sp_exe().returning(|_, _| {});
         RawCurp::new_test(3, exe_tx)
     };
     let cmd = Arc::new(TestCommand::default());
@@ -81,7 +81,7 @@ fn leader_handle_propose_will_succeed() {
 fn leader_handle_propose_will_reject_conflicted() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
-        exe_tx.expect_send_sp_exe().returning(|_| {});
+        exe_tx.expect_send_sp_exe().returning(|_, _| {});
         RawCurp::new_test(3, exe_tx)
     };
 
@@ -110,7 +110,7 @@ fn leader_handle_propose_will_reject_conflicted() {
 fn leader_handle_propose_will_reject_duplicated() {
     let curp = {
         let mut exe_tx = MockCEEventTxApi::<TestCommand>::default();
-        exe_tx.expect_send_sp_exe().returning(|_| {});
+        exe_tx.expect_send_sp_exe().returning(|_, _| {});
         RawCurp::new_test(3, exe_tx)
     };
     let cmd = Arc::new(TestCommand::default());

--- a/curp/src/test_utils/test_cmd.rs
+++ b/curp/src/test_utils/test_cmd.rs
@@ -211,7 +211,7 @@ impl CommandExecutor<TestCommand> for TestCE {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
-        _pre_exe_res: Option<<TestCommand as Command>::PR>,
+        _pre_exe_res: <TestCommand as Command>::PR,
     ) -> Result<<TestCommand as Command>::ASR, Self::Error> {
         sleep(cmd.as_dur).await;
         if cmd.as_should_fail {
@@ -335,7 +335,7 @@ impl CommandExecutor<TestCommand> for TestCESimple {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
-        _pre_exe_res: Option<<TestCommand as Command>::PR>,
+        _pre_exe_res: <TestCommand as Command>::PR,
     ) -> Result<<TestCommand as Command>::ASR, Self::Error> {
         sleep(cmd.as_dur).await;
         if cmd.as_should_fail {

--- a/curp/src/test_utils/test_cmd.rs
+++ b/curp/src/test_utils/test_cmd.rs
@@ -211,7 +211,6 @@ impl CommandExecutor<TestCommand> for TestCE {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
-        need_run: bool,
         _pre_exe_res: Option<<TestCommand as Command>::PR>,
     ) -> Result<<TestCommand as Command>::ASR, Self::Error> {
         sleep(cmd.as_dur).await;
@@ -220,11 +219,9 @@ impl CommandExecutor<TestCommand> for TestCE {
         }
         self.last_applied
             .store(index.numeric_cast(), Ordering::Relaxed);
-        if need_run {
-            self.after_sync_sender
-                .send((cmd.clone(), index))
-                .expect("failed to send after sync msg");
-        }
+        self.after_sync_sender
+            .send((cmd.clone(), index))
+            .expect("failed to send after sync msg");
         Ok(index)
     }
 
@@ -338,7 +335,6 @@ impl CommandExecutor<TestCommand> for TestCESimple {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
-        _need_run: bool,
         _pre_exe_res: Option<<TestCommand as Command>::PR>,
     ) -> Result<<TestCommand as Command>::ASR, Self::Error> {
         sleep(cmd.as_dur).await;

--- a/curp/src/test_utils/test_cmd.rs
+++ b/curp/src/test_utils/test_cmd.rs
@@ -155,13 +155,18 @@ impl Display for ExecuteError {
 impl CommandExecutor<TestCommand> for TestCE {
     type Error = ExecuteError;
 
-    fn prepare(&self, _cmd: &TestCommand) -> Result<<TestCommand as Command>::PR, Self::Error> {
+    fn prepare(
+        &self,
+        _cmd: &TestCommand,
+        _index: LogIndex,
+    ) -> Result<<TestCommand as Command>::PR, Self::Error> {
         Ok(0)
     }
 
     async fn execute(
         &self,
         cmd: &TestCommand,
+        _index: LogIndex,
     ) -> Result<<TestCommand as Command>::ER, Self::Error> {
         sleep(cmd.exe_dur).await;
         if cmd.exe_should_fail {
@@ -280,13 +285,18 @@ pub(crate) struct TestCESimple {
 impl CommandExecutor<TestCommand> for TestCESimple {
     type Error = ExecuteError;
 
-    fn prepare(&self, _cmd: &TestCommand) -> Result<<TestCommand as Command>::PR, Self::Error> {
+    fn prepare(
+        &self,
+        _cmd: &TestCommand,
+        _index: LogIndex,
+    ) -> Result<<TestCommand as Command>::PR, Self::Error> {
         Ok(0)
     }
 
     async fn execute(
         &self,
         cmd: &TestCommand,
+        _index: LogIndex,
     ) -> Result<<TestCommand as Command>::ER, Self::Error> {
         sleep(cmd.exe_dur).await;
         if cmd.exe_should_fail {

--- a/curp/tests/common/test_cmd.rs
+++ b/curp/tests/common/test_cmd.rs
@@ -151,7 +151,11 @@ pub struct TestCE {
 impl CommandExecutor<TestCommand> for TestCE {
     type Error = ExecuteError;
 
-    fn prepare(&self, cmd: &TestCommand) -> Result<<TestCommand as Command>::PR, Self::Error> {
+    fn prepare(
+        &self,
+        cmd: &TestCommand,
+        _index: LogIndex,
+    ) -> Result<<TestCommand as Command>::PR, Self::Error> {
         let rev = if let TestCommandType::Put(_) = cmd.cmd_type {
             self.revision.fetch_add(1, Ordering::Relaxed)
         } else {
@@ -163,6 +167,7 @@ impl CommandExecutor<TestCommand> for TestCE {
     async fn execute(
         &self,
         cmd: &TestCommand,
+        _index: LogIndex,
     ) -> Result<<TestCommand as Command>::ER, Self::Error> {
         sleep(cmd.exe_dur).await;
         if cmd.exe_should_fail {

--- a/curp/tests/common/test_cmd.rs
+++ b/curp/tests/common/test_cmd.rs
@@ -224,7 +224,7 @@ impl CommandExecutor<TestCommand> for TestCE {
         &self,
         cmd: &TestCommand,
         index: LogIndex,
-        revision: Option<<TestCommand as Command>::PR>,
+        revision: <TestCommand as Command>::PR,
     ) -> Result<<TestCommand as Command>::ASR, Self::Error> {
         sleep(cmd.as_dur).await;
         if cmd.as_should_fail {
@@ -234,7 +234,6 @@ impl CommandExecutor<TestCommand> for TestCE {
             .send((cmd.clone(), index))
             .expect("failed to send after sync msg");
         if let TestCommandType::Put(_) = cmd.cmd_type {
-            let revision = revision.expect("revision should not be None");
             debug!(
                 "cmd {:?}-{} revision is {}",
                 cmd.cmd_type,

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -313,12 +313,9 @@ where
         &self,
         cmd: &Command,
         index: LogIndex,
-        revision: Option<i64>,
+        revision: i64,
     ) -> Result<<Command as CurpCommand>::ASR, Self::Error> {
         let mut ops = vec![WriteOp::PutAppliedIndex(index)];
-        #[allow(clippy::unwrap_used)]
-        // TODO: is there really need an option?
-        let revision = revision.unwrap();
         let wrapper = cmd.request();
         let (res, mut wr_ops) = match wrapper.request.backend() {
             RequestBackend::Kv => self.kv_storage.after_sync(wrapper, revision).await?,

--- a/xline/src/server/kv_server.rs
+++ b/xline/src/server/kv_server.rs
@@ -365,6 +365,7 @@ where
             let wait_future = async move {
                 match rd_state {
                     ReadState::Ids(ids) => {
+                        debug!(?ids, "Range wait for command ids");
                         let fus = ids
                             .into_iter()
                             .map(|id| self.id_barrier.wait(id))
@@ -372,6 +373,7 @@ where
                         let _ignore = join_all(fus).await;
                     }
                     ReadState::CommitIndex(index) => {
+                        debug!(?index, "Range wait for commit index");
                         self.index_barrier.wait(index).await;
                     }
                     _ => unreachable!(),


### PR DESCRIPTION
Close #270 
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)
Optimize the trigger of `IndexBarrier` and `IdBarrier`
* what changes does this pull request make?
trigger them when a command prepare/execute failed, only run necessary stages.
* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)
change interface of `CommandExecutor`