### PR TITLE
fix: fix build with gcc 13 by bumping rust-rocksdb to v0.21.0

### DIFF
--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 
 [dependencies]
 parking_lot = "0.12.1"
-rocksdb = { version = "0.20.1", features = ["multi-threaded-cf"] }
+rocksdb = { version = "0.21.0", features = ["multi-threaded-cf"] }
 thiserror = "1.0.38"
 serde = { version = "1.0.152", features = ["derive"] }
 bincode = "1.3.3"


### PR DESCRIPTION
see https://github.com/facebook/rocksdb/pull/11118

rust-rocksdb v0.21.0 have included this commit

Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

* what changes does this pull request make?

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)