### PR TITLE
Chore/Bump Rust toolchain to 1.70.0

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -6,7 +6,7 @@ on:
     - cron: "00 00 * * 1"
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.70.0
 
 jobs:
   becnmark:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.70.0
 
 jobs:
   outdated:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ on:
     branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.70.0
 
 jobs:
   coverage:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: {}
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.70.0
 
 jobs:
   docker:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - "v*"
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.70.0
 
 jobs:
   build:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,7 +5,7 @@ on:
     branches: [master]
 
 env:
-  CI_RUST_TOOLCHAIN: 1.67.1
+  CI_RUST_TOOLCHAIN: 1.70.0
 
 jobs:
   benchmark:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,7 @@ Check the code format.
 cargo fmt --all -- --check
 ```
 
-**Note**: The current version of the Rust toolchain used for CI is **1.61.0** .
+**Note**: The current version of the Rust toolchain used for CI is **1.70.0** .
 Please use this version to run the above command, otherwise you may get
 different results with CI.
 

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -104,6 +104,32 @@
     // clippy::use_debug, debug is allow for debug log
     clippy::verbose_file_reads,
     clippy::wildcard_enum_match_arm,
+
+    // The followings are selected lints from 1.61.0 to 1.67.1
+    clippy::as_ptr_cast_mut,
+    clippy::derive_partial_eq_without_eq,
+    clippy::empty_drop,
+    clippy::empty_structs_with_brackets,
+    clippy::format_push_string,
+    clippy::iter_on_empty_collections,
+    clippy::iter_on_single_items,
+    clippy::large_include_file,
+    clippy::manual_clamp,
+    clippy::suspicious_xor_used_as_pow,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::unused_peekable,
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/benchmark/src/runner.rs
+++ b/benchmark/src/runner.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    fmt::Write as _,
     sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -67,30 +68,20 @@ impl Stats {
     }
 
     /// Summary of stats
+    #[allow(clippy::let_underscore_must_use)] // the writeln! will not fail thus always return an Ok
     pub fn summary(&self) -> String {
         let mut s = String::from("\nSummary:\n");
-        s.push_str(&format!(
-            "  Total:        {:.4} secs\n",
-            self.total.as_secs_f64()
-        ));
-        s.push_str(&format!(
-            "  Slowest:      {:.4} secs\n",
-            self.slowest.as_secs_f64()
-        ));
-        s.push_str(&format!(
-            "  Fastest:      {:.4} secs\n",
-            self.fastest.as_secs_f64()
-        ));
-        s.push_str(&format!(
-            "  Average:      {:.4} secs\n",
-            self.avg.as_secs_f64()
-        ));
-        s.push_str(&format!("  Requests/sec: {:.2}\n", self.qps));
+        _ = writeln!(s, "  Total:        {:.4} secs", self.total.as_secs_f64());
+        _ = writeln!(s, "  Slowest:      {:.4} secs", self.slowest.as_secs_f64());
+        _ = writeln!(s, "  Fastest:      {:.4} secs", self.fastest.as_secs_f64());
+        _ = writeln!(s, "  Average:      {:.4} secs", self.avg.as_secs_f64());
+        _ = writeln!(s, "  Requests/sec: {:.2}", self.qps);
         s
     }
 
     /// Calculate the histogram from the latencies.
     #[allow(clippy::indexing_slicing)]
+    #[allow(clippy::let_underscore_must_use)] // the writeln! will not fail thus always return an Ok
     pub fn histogram(&self) -> String {
         let size = 10;
         let mut buckets = Vec::with_capacity(size);
@@ -112,12 +103,13 @@ impl Stats {
         let mut s = String::from("\nResponse time histogram:\n");
         for i in 0..size {
             let bar_len = counts[i].overflow_mul(40).overflow_div(max);
-            s.push_str(&format!(
-                "  {:.4}\t[{}]\t| {}\n",
+            _ = writeln!(
+                s,
+                "  {:.4}\t[{}]\t| {}",
                 buckets[i].as_secs_f64(),
                 counts[i],
                 "∎".repeat(bar_len)
-            ));
+            );
         }
         s
     }
@@ -208,7 +200,7 @@ impl CommandRunner {
             let tx_clone = tx.clone();
             let handle = tokio::spawn(async move {
                 let mut key = vec![0u8; key_size];
-                let _ = c.wait().await;
+                _ = c.wait().await;
                 loop {
                     let idx = count_clone.fetch_add(1, Ordering::Relaxed);
                     if idx >= total {
@@ -268,7 +260,7 @@ impl CommandRunner {
             });
         }
         let mut stats = Stats::new();
-        let _ = barrier.wait().await;
+        _ = barrier.wait().await;
         debug!("Collecting benchmark results...");
         let start = Instant::now();
         while let Some(result) = rx.recv().await {

--- a/curp-external-api/src/lib.rs
+++ b/curp-external-api/src/lib.rs
@@ -119,7 +119,17 @@
     clippy::unnecessary_safety_comment,
     clippy::unnecessary_safety_doc,
     clippy::unused_peekable,
-    clippy::unused_rounding
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 
 /// Log Index

--- a/curp/src/lib.rs
+++ b/curp/src/lib.rs
@@ -119,7 +119,17 @@
     clippy::unnecessary_safety_comment,
     clippy::unnecessary_safety_doc,
     clippy::unused_peekable,
-    clippy::unused_rounding
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/curp/src/server/cmd_board.rs
+++ b/curp/src/server/cmd_board.rs
@@ -144,7 +144,7 @@ impl<C: Command> CommandBoard<C> {
                     (Some(er), Some(asr)) => return (er.clone(), Some(asr.clone())),
                     _ => {}
                 }
-            };
+            }
             let listener = cb.write().asr_listener(id);
             listener.await;
         }

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -118,7 +118,17 @@ clippy::suspicious_xor_used_as_pow,
 clippy::unnecessary_safety_comment,
 clippy::unnecessary_safety_doc,
 clippy::unused_peekable,
-clippy::unused_rounding
+clippy::unused_rounding,
+
+// The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+// clippy::allow_attributes, still unstable
+clippy::impl_trait_in_params,
+clippy::let_underscore_untyped,
+clippy::missing_assert_message,
+clippy::multiple_unsafe_ops_per_block,
+clippy::semicolon_inside_block,
+// clippy::semicolon_outside_block, already used `semicolon_inside_block`
+clippy::tests_outside_test_module
 )]
 #![allow(
 clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.67.1"
+channel = "1.70.0"
 components = ["rustfmt", "clippy", "rust-src"]

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -119,7 +119,17 @@
     clippy::unnecessary_safety_comment,
     clippy::unnecessary_safety_doc,
     clippy::unused_peekable,
-    clippy::unused_rounding
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/xline-client/src/lib.rs
+++ b/xline-client/src/lib.rs
@@ -387,7 +387,7 @@ where
     #[inline]
     fn call(&mut self, mut request: Request<Body>) -> Self::Future {
         if let Some(token) = self.token.as_ref() {
-            let _ = request
+            let _: Option<HeaderValue> = request
                 .headers_mut()
                 .insert(AUTHORIZATION, token.as_ref().clone());
         }

--- a/xline-client/src/lib.rs
+++ b/xline-client/src/lib.rs
@@ -119,7 +119,17 @@
     clippy::unnecessary_safety_comment,
     clippy::unnecessary_safety_doc,
     clippy::unused_peekable,
-    clippy::unused_rounding
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 #![allow(
     clippy::multiple_crate_versions, // caused by the dependency, can't be fixed

--- a/xline/src/client/restore.rs
+++ b/xline/src/client/restore.rs
@@ -14,9 +14,9 @@ use crate::{server::MAINTENANCE_SNAPSHOT_CHUNK_SIZE, storage::db::XLINE_TABLES};
 /// return `ClientError::EngineError` if meet engine errors
 #[inline]
 #[allow(clippy::indexing_slicing)] // safe operation
-pub async fn restore(
-    snapshot_path: impl AsRef<Path>,
-    data_dir: impl Into<PathBuf>,
+pub async fn restore<P: AsRef<Path>, D: Into<PathBuf>>(
+    snapshot_path: P,
+    data_dir: D,
 ) -> Result<(), ClientError> {
     let mut snapshot_f = tokio::fs::File::open(snapshot_path).await?;
     let tmp_path = format!("/tmp/snapshot-{}", uuid::Uuid::new_v4());

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -119,7 +119,17 @@
     clippy::unnecessary_safety_comment,
     clippy::unnecessary_safety_doc,
     clippy::unused_peekable,
-    clippy::unused_rounding
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 #![allow(
     clippy::panic, // allow debug_assert, panic in production code

--- a/xline/src/lib.rs
+++ b/xline/src/lib.rs
@@ -144,7 +144,8 @@
         clippy::unwrap_used,
         clippy::as_conversions,
         clippy::shadow_unrelated,
-        clippy::integer_arithmetic
+        clippy::integer_arithmetic,
+        clippy::let_underscore_untyped,
     )
 )]
 

--- a/xline/src/main.rs
+++ b/xline/src/main.rs
@@ -104,6 +104,32 @@
     // clippy::use_debug, debug is allow for debug log
     clippy::verbose_file_reads,
     clippy::wildcard_enum_match_arm,
+
+    // The followings are selected lints from 1.61.0 to 1.67.1
+    clippy::as_ptr_cast_mut,
+    clippy::derive_partial_eq_without_eq,
+    clippy::empty_drop,
+    clippy::empty_structs_with_brackets,
+    clippy::format_push_string,
+    clippy::iter_on_empty_collections,
+    clippy::iter_on_single_items,
+    clippy::large_include_file,
+    clippy::manual_clamp,
+    clippy::suspicious_xor_used_as_pow,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::unused_peekable,
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 #![allow(
     clippy::panic, // allow debug_assert, panic in production code

--- a/xline/src/server/command.rs
+++ b/xline/src/server/command.rs
@@ -89,7 +89,10 @@ impl KeyRange {
     #[inline]
     pub fn new_one_key(key: impl Into<Vec<u8>>) -> Self {
         let key_vec = key.into();
-        assert!(key_vec.as_slice() != UNBOUNDED);
+        assert!(
+            key_vec.as_slice() != UNBOUNDED,
+            "Unbounded key is not allowed: {key_vec:?}",
+        );
         Self {
             key: Bound::Included(key_vec.clone()),
             range_end: Bound::Included(key_vec),

--- a/xline/src/storage/index.rs
+++ b/xline/src/storage/index.rs
@@ -222,10 +222,13 @@ impl IndexOperate for Index {
                 .unzip(),
         };
         if !keys.is_empty() {
-            assert!(inner
-                .unavailable_cache
-                .insert(revision, keys.clone())
-                .is_none());
+            assert!(
+                inner
+                    .unavailable_cache
+                    .insert(revision, keys.clone())
+                    .is_none(),
+                "revision {revision} is already in the unavailable cache",
+            );
         }
         (pairs, keys)
     }

--- a/xline/src/storage/kvwatcher.rs
+++ b/xline/src/storage/kvwatcher.rs
@@ -262,7 +262,10 @@ impl WatcherMap {
                 watch_ids.is_empty()
             };
             if is_empty {
-                assert!(self.index.remove(key_range).is_some());
+                assert!(
+                    self.index.remove(key_range).is_some(),
+                    "watch_ids should exist"
+                );
             }
         } else {
             self.victims = self

--- a/xlineapi/src/lib.rs
+++ b/xlineapi/src/lib.rs
@@ -119,7 +119,17 @@
     clippy::unnecessary_safety_comment,
     clippy::unnecessary_safety_doc,
     clippy::unused_peekable,
-    clippy::unused_rounding
+    clippy::unused_rounding,
+
+    // The followings are selected restriction lints from rust 1.68.0 to 1.70.0
+    // clippy::allow_attributes, still unstable
+    clippy::impl_trait_in_params,
+    clippy::let_underscore_untyped,
+    clippy::missing_assert_message,
+    clippy::multiple_unsafe_ops_per_block,
+    clippy::semicolon_inside_block,
+    // clippy::semicolon_outside_block, already used `semicolon_inside_block`
+    clippy::tests_outside_test_module
 )]
 // Skip for generated code
 #![allow(


### PR DESCRIPTION
Please briefly answer these questions:

* what problem are you trying to solve? (or if there's no problem, what's the motivation for this change?)

    Described in #336 

* what changes does this pull request make?

    Bump Rust toolchain to 1.70.0

* are there any non-obvious implications of these changes? (does it break compatibility with previous versions, etc)